### PR TITLE
feat: add core APIs for housekeeping web frontend

### DIFF
--- a/housekeeping/src/main/java/com/example/housekeeping/config/DataInitializer.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/config/DataInitializer.java
@@ -1,0 +1,111 @@
+package com.example.housekeeping.config;
+
+import com.example.housekeeping.model.AccountType;
+import com.example.housekeeping.model.BookingStatus;
+import com.example.housekeeping.model.ServiceBooking;
+import com.example.housekeeping.model.ServiceItem;
+import com.example.housekeeping.model.UserAccount;
+import com.example.housekeeping.repository.ServiceBookingRepository;
+import com.example.housekeeping.repository.ServiceItemRepository;
+import com.example.housekeeping.repository.UserAccountRepository;
+import com.example.housekeeping.service.AuthService;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class DataInitializer {
+
+    private static final Logger log = LoggerFactory.getLogger(DataInitializer.class);
+
+    private final UserAccountRepository userAccountRepository;
+    private final ServiceItemRepository serviceItemRepository;
+    private final ServiceBookingRepository serviceBookingRepository;
+    private final AuthService authService;
+
+    public DataInitializer(UserAccountRepository userAccountRepository,
+                           ServiceItemRepository serviceItemRepository,
+                           ServiceBookingRepository serviceBookingRepository,
+                           AuthService authService) {
+        this.userAccountRepository = userAccountRepository;
+        this.serviceItemRepository = serviceItemRepository;
+        this.serviceBookingRepository = serviceBookingRepository;
+        this.authService = authService;
+    }
+
+    @PostConstruct
+    public void init() {
+        initAccounts();
+        initServices();
+        initBookings();
+    }
+
+    private void initAccounts() {
+        createAccountIfMissing("admin", "Admin@123", AccountType.ADMIN, BigDecimal.ZERO);
+        createAccountIfMissing("demo_user", "User@123", AccountType.USER, BigDecimal.valueOf(1500));
+        createAccountIfMissing("demo_provider", "Provider@123", AccountType.PROVIDER, BigDecimal.ZERO);
+    }
+
+    private void createAccountIfMissing(String username, String password, AccountType type, BigDecimal balance) {
+        userAccountRepository.findByUserNameIgnoreCase(username).ifPresentOrElse(account -> {
+            if (account.getMoney().compareTo(balance) != 0) {
+                account.setMoney(balance);
+                userAccountRepository.save(account);
+            }
+        }, () -> {
+            UserAccount account = new UserAccount(username, authService.encodePassword(password), type.name(), balance);
+            account.setTypes(type);
+            account.setMoney(balance);
+            userAccountRepository.save(account);
+            log.info("初始化账号: {}", username);
+        });
+    }
+
+    private void initServices() {
+        if (serviceItemRepository.count() > 0) {
+            return;
+        }
+
+        List<ServiceItem> items = List.of(
+                new ServiceItem("家庭日常保洁", "2小时基础保洁，覆盖客厅、卧室与卫生间。", BigDecimal.valueOf(128)),
+                new ServiceItem("深度厨房清洁", "针对油污重灾区的厨房提供除油、消毒一体化服务。", BigDecimal.valueOf(258)),
+                new ServiceItem("全屋开荒保洁", "适合新房入住前的全面清洁，含窗户与地面打蜡。", BigDecimal.valueOf(398)),
+                new ServiceItem("家电专业清洗", "空调、油烟机、洗衣机等家电专业拆洗与杀菌。", BigDecimal.valueOf(198))
+        );
+        serviceItemRepository.saveAll(items);
+        log.info("初始化服务项目 {} 个", items.size());
+    }
+
+    private void initBookings() {
+        if (serviceBookingRepository.count() > 0) {
+            return;
+        }
+
+        ServiceItem defaultItem = serviceItemRepository.findByNameIgnoreCase("家庭日常保洁")
+                .orElseGet(() -> serviceItemRepository.findAll().stream().findFirst().orElse(null));
+
+        if (defaultItem == null) {
+            return;
+        }
+
+        ServiceBooking booking = new ServiceBooking();
+        booking.setCustomerName("张女士");
+        booking.setPhone("13800001234");
+        booking.setAddress("上海市浦东新区花木路88号");
+        booking.setServiceDate(LocalDate.now().plusDays(1));
+        booking.setNotes("上午9点前到达，门禁8888。");
+        booking.setStatus(BookingStatus.PENDING);
+        booking.setCreatedBy("demo_user");
+        booking.setServiceItem(defaultItem);
+        booking.setPrice(defaultItem.getPrice());
+
+        serviceBookingRepository.save(booking);
+        log.info("初始化示例预约数据");
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/AuthController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/AuthController.java
@@ -27,7 +27,7 @@ public class AuthController {
         UserAccount account = authService.register(request.getUsername(), request.getPassword(), request.getType());
         Map<String, Object> payload = Map.of(
                 "userName", account.getUserName(),
-                "types", account.getTypes(),
+                "types", account.getTypes().name(),
                 "money", account.getMoney()
         );
         return ResponseEntity.ok(payload);

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/BookingController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/BookingController.java
@@ -1,0 +1,252 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.model.AccountType;
+import com.example.housekeeping.model.ServiceBooking;
+import com.example.housekeeping.model.ServiceItem;
+import com.example.housekeeping.service.BookingService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/bookings")
+public class BookingController {
+
+    private final BookingService bookingService;
+
+    public BookingController(BookingService bookingService) {
+        this.bookingService = bookingService;
+    }
+
+    @GetMapping
+    public List<BookingView> listAll() {
+        return bookingService.findAll().stream().map(BookingController::toView).collect(Collectors.toList());
+    }
+
+    @GetMapping("/mine")
+    public List<BookingView> listMine(HttpServletRequest request) {
+        String username = (String) request.getAttribute("username");
+        String userTypeRaw = (String) request.getAttribute("userType");
+        AccountType userType = StringUtils.hasText(userTypeRaw) ? AccountType.from(userTypeRaw) : AccountType.USER;
+
+        List<ServiceBooking> bookings;
+        if (userType == AccountType.PROVIDER) {
+            bookings = bookingService.findAssignedBookings(username);
+        } else {
+            bookings = bookingService.findMyBookings(username);
+        }
+        return bookings.stream().map(BookingController::toView).collect(Collectors.toList());
+    }
+
+    @PostMapping
+    public ResponseEntity<BookingView> create(@RequestBody @Valid BookingRequest requestBody, HttpServletRequest request) {
+        String username = (String) request.getAttribute("username");
+        if (!StringUtils.hasText(username)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "登录状态已失效");
+        }
+
+        LocalDate serviceDate = parseDate(requestBody.getServiceDate());
+        ServiceBooking booking = bookingService.createBooking(
+                requestBody.getCustomerName(),
+                requestBody.getPhone(),
+                requestBody.getAddress(),
+                serviceDate,
+                requestBody.getNotes(),
+                requestBody.getServiceItemId(),
+                username
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(toView(booking));
+    }
+
+    @PutMapping("/{id}")
+    public BookingView update(@PathVariable Long id,
+                              @RequestBody @Valid BookingRequest requestBody,
+                              HttpServletRequest request) {
+        String username = (String) request.getAttribute("username");
+        String userTypeRaw = (String) request.getAttribute("userType");
+        boolean isAdmin = StringUtils.hasText(userTypeRaw) && AccountType.from(userTypeRaw) == AccountType.ADMIN;
+
+        if (!StringUtils.hasText(username)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "登录状态已失效");
+        }
+
+        LocalDate serviceDate = parseDate(requestBody.getServiceDate());
+        ServiceBooking booking = bookingService.updateBooking(
+                id,
+                requestBody.getCustomerName(),
+                requestBody.getPhone(),
+                requestBody.getAddress(),
+                serviceDate,
+                requestBody.getNotes(),
+                requestBody.getServiceItemId(),
+                username,
+                isAdmin
+        );
+
+        return toView(booking);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, HttpServletRequest request) {
+        String username = (String) request.getAttribute("username");
+        String userTypeRaw = (String) request.getAttribute("userType");
+        boolean isAdmin = StringUtils.hasText(userTypeRaw) && AccountType.from(userTypeRaw) == AccountType.ADMIN;
+
+        if (!StringUtils.hasText(username)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "登录状态已失效");
+        }
+
+        bookingService.deleteBooking(id, username, isAdmin);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/accept")
+    public BookingView accept(@PathVariable Long id, HttpServletRequest request) {
+        String username = (String) request.getAttribute("username");
+        String userTypeRaw = (String) request.getAttribute("userType");
+        AccountType userType = StringUtils.hasText(userTypeRaw) ? AccountType.from(userTypeRaw) : AccountType.USER;
+
+        if (userType != AccountType.PROVIDER) {
+            throw new AccessDeniedException("仅家政服务人员可接受预约");
+        }
+
+        ServiceBooking booking = bookingService.acceptBooking(id, username);
+        return toView(booking);
+    }
+
+    private static BookingView toView(ServiceBooking booking) {
+        ServiceItem item = booking.getServiceItem();
+        ServiceItemView itemView = new ServiceItemView(
+                item.getId(),
+                item.getName(),
+                item.getDescription(),
+                item.getPrice()
+        );
+
+        return new BookingView(
+                booking.getId(),
+                booking.getCustomerName(),
+                booking.getPhone(),
+                booking.getAddress(),
+                booking.getServiceDate(),
+                booking.getNotes(),
+                booking.getStatus().name(),
+                booking.getPrice(),
+                booking.getCreatedBy(),
+                booking.getAssignedProvider(),
+                itemView
+        );
+    }
+
+    private LocalDate parseDate(String rawDate) {
+        try {
+            return LocalDate.parse(rawDate);
+        } catch (DateTimeParseException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "预约日期格式不正确，需使用YYYY-MM-DD格式");
+        }
+    }
+
+    public static class BookingRequest {
+
+        @NotBlank
+        @Size(max = 100)
+        private String customerName;
+
+        @NotBlank
+        @Size(max = 30)
+        private String phone;
+
+        @NotBlank
+        private String address;
+
+        @NotBlank
+        @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}")
+        private String serviceDate;
+
+        private String notes;
+
+        @NotNull
+        private Long serviceItemId;
+
+        public String getCustomerName() {
+            return customerName;
+        }
+
+        public void setCustomerName(String customerName) {
+            this.customerName = customerName;
+        }
+
+        public String getPhone() {
+            return phone;
+        }
+
+        public void setPhone(String phone) {
+            this.phone = phone;
+        }
+
+        public String getAddress() {
+            return address;
+        }
+
+        public void setAddress(String address) {
+            this.address = address;
+        }
+
+        public String getServiceDate() {
+            return serviceDate;
+        }
+
+        public void setServiceDate(String serviceDate) {
+            this.serviceDate = serviceDate;
+        }
+
+        public String getNotes() {
+            return notes;
+        }
+
+        public void setNotes(String notes) {
+            this.notes = notes;
+        }
+
+        public Long getServiceItemId() {
+            return serviceItemId;
+        }
+
+        public void setServiceItemId(Long serviceItemId) {
+            this.serviceItemId = serviceItemId;
+        }
+    }
+
+    public record ServiceItemView(Long id, String name, String description, BigDecimal price) {
+    }
+
+    public record BookingView(Long id,
+                              String customerName,
+                              String phone,
+                              String address,
+                              LocalDate serviceDate,
+                              String notes,
+                              String status,
+                              BigDecimal price,
+                              String createdBy,
+                              String assignedProvider,
+                              ServiceItemView serviceItem) {
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/ServiceItemController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/ServiceItemController.java
@@ -1,0 +1,26 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.model.ServiceItem;
+import com.example.housekeeping.service.ServiceItemService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/services")
+public class ServiceItemController {
+
+    private final ServiceItemService serviceItemService;
+
+    public ServiceItemController(ServiceItemService serviceItemService) {
+        this.serviceItemService = serviceItemService;
+    }
+
+    @GetMapping
+    public List<ServiceItem> list() {
+        return serviceItemService.findAll();
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/WalletController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/WalletController.java
@@ -1,0 +1,50 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.model.UserAccount;
+import com.example.housekeeping.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/wallet")
+public class WalletController {
+
+    private final AuthService authService;
+
+    public WalletController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<Map<String, Object>> getWallet(HttpServletRequest request) {
+        String username = (String) request.getAttribute("username");
+        if (!StringUtils.hasText(username)) {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.getName() != null) {
+                username = authentication.getName();
+            }
+        }
+
+        if (!StringUtils.hasText(username)) {
+            return ResponseEntity.status(401).body(Map.of("message", "未登录或登录信息已过期"));
+        }
+
+        UserAccount account = authService.findByUsername(username);
+        Map<String, Object> payload = Map.of(
+                "userName", account.getUserName(),
+                "types", account.getTypes().name(),
+                "money", account.getMoney(),
+                "role", account.getTypes().name()
+        );
+        return ResponseEntity.ok(payload);
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/model/AccountType.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/model/AccountType.java
@@ -1,0 +1,30 @@
+package com.example.housekeeping.model;
+
+/**
+ * 系统支持的账号类型。
+ */
+public enum AccountType {
+    ADMIN,
+    USER,
+    PROVIDER;
+
+    /**
+     * 将任意字符串安全转换为 {@link AccountType}。
+     *
+     * @param rawType 前端传入的类型字符串
+     * @return 枚举值
+     * @throws IllegalArgumentException 当类型不在预期范围内时抛出
+     */
+    public static AccountType from(String rawType) {
+        if (rawType == null) {
+            throw new IllegalArgumentException("账号类型不能为空");
+        }
+
+        try {
+            return AccountType.valueOf(rawType.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("不支持的账号类型: " + rawType);
+        }
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/model/BookingStatus.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/model/BookingStatus.java
@@ -1,0 +1,13 @@
+package com.example.housekeeping.model;
+
+/**
+ * 预约处理状态。
+ */
+public enum BookingStatus {
+    PENDING,
+    ACCEPTED,
+    IN_PROGRESS,
+    COMPLETED,
+    CANCELLED
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/model/ServiceBooking.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/model/ServiceBooking.java
@@ -1,0 +1,165 @@
+package com.example.housekeeping.model;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 精简后的预约实体，与前端的预约列表保持一致。
+ */
+@Entity
+@Table(name = "hk_service_booking")
+public class ServiceBooking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "customer_name", nullable = false, length = 100)
+    private String customerName;
+
+    @Column(name = "phone", nullable = false, length = 30)
+    private String phone;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "service_date", nullable = false)
+    private LocalDate serviceDate;
+
+    @Column(name = "notes", columnDefinition = "text")
+    private String notes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private BookingStatus status = BookingStatus.PENDING;
+
+    @Column(name = "price", nullable = false, precision = 10, scale = 2)
+    private BigDecimal price;
+
+    @Column(name = "created_by", nullable = false, length = 100)
+    private String createdBy;
+
+    @Column(name = "assigned_provider", length = 100)
+    private String assignedProvider;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "service_item_id")
+    private ServiceItem serviceItem;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        if (this.status == null) {
+            this.status = BookingStatus.PENDING;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getCustomerName() {
+        return customerName;
+    }
+
+    public void setCustomerName(String customerName) {
+        this.customerName = customerName;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public LocalDate getServiceDate() {
+        return serviceDate;
+    }
+
+    public void setServiceDate(LocalDate serviceDate) {
+        this.serviceDate = serviceDate;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public BookingStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(BookingStatus status) {
+        this.status = status;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public void setPrice(BigDecimal price) {
+        this.price = price;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public String getAssignedProvider() {
+        return assignedProvider;
+    }
+
+    public void setAssignedProvider(String assignedProvider) {
+        this.assignedProvider = assignedProvider;
+    }
+
+    public ServiceItem getServiceItem() {
+        return serviceItem;
+    }
+
+    public void setServiceItem(ServiceItem serviceItem) {
+        this.serviceItem = serviceItem;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/model/ServiceItem.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/model/ServiceItem.java
@@ -1,0 +1,91 @@
+package com.example.housekeeping.model;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 面向前端展示的家政服务项目。
+ */
+@Entity
+@Table(name = "hk_service_item")
+public class ServiceItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true, length = 120)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "text")
+    private String description;
+
+    @Column(name = "price", nullable = false, precision = 10, scale = 2)
+    private BigDecimal price;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public ServiceItem() {
+    }
+
+    public ServiceItem(String name, String description, BigDecimal price) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public void setPrice(BigDecimal price) {
+        this.price = price;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/model/UserAccount.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/model/UserAccount.java
@@ -1,0 +1,104 @@
+package com.example.housekeeping.model;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 与前端登录注册流程配套的账号实体。
+ */
+@Entity
+@Table(name = "hk_user_account")
+public class UserAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_name", nullable = false, unique = true, length = 100)
+    private String userName;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "types", nullable = false, length = 20)
+    private AccountType types;
+
+    @Column(name = "money", nullable = false, precision = 12, scale = 2)
+    private BigDecimal money = BigDecimal.ZERO;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public UserAccount() {
+    }
+
+    public UserAccount(String userName, String password, String type, BigDecimal money) {
+        this.userName = userName;
+        this.password = password;
+        this.types = AccountType.from(type);
+        this.money = money;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public AccountType getTypes() {
+        return types;
+    }
+
+    public void setTypes(AccountType types) {
+        this.types = types;
+    }
+
+    public BigDecimal getMoney() {
+        return money;
+    }
+
+    public void setMoney(BigDecimal money) {
+        this.money = money;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceBookingRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceBookingRepository.java
@@ -2,11 +2,16 @@ package com.example.housekeeping.repository;
 
 import com.example.housekeeping.model.ServiceBooking;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface ServiceBookingRepository extends JpaRepository<ServiceBooking, Long> {
-    List<ServiceBooking> findAllByCreatedByOrderByServiceDateDesc(String createdBy);
 
-    List<ServiceBooking> findAllByOrderByServiceDateDesc();
+    List<ServiceBooking> findAllByOrderByCreatedAtDesc();
+
+    List<ServiceBooking> findByCreatedByOrderByCreatedAtDesc(String createdBy);
+
+    List<ServiceBooking> findByAssignedProviderOrderByCreatedAtDesc(String assignedProvider);
 }

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceItemRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceItemRepository.java
@@ -1,0 +1,16 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.model.ServiceItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ServiceItemRepository extends JpaRepository<ServiceItem, Long> {
+
+    boolean existsByNameIgnoreCase(String name);
+
+    Optional<ServiceItem> findByNameIgnoreCase(String name);
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/UserAccountRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/UserAccountRepository.java
@@ -1,0 +1,16 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.model.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+
+    boolean existsByUserNameIgnoreCase(String userName);
+
+    Optional<UserAccount> findByUserNameIgnoreCase(String userName);
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/service/BookingService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/BookingService.java
@@ -1,0 +1,118 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.model.BookingStatus;
+import com.example.housekeeping.model.ServiceBooking;
+import com.example.housekeeping.model.ServiceItem;
+import com.example.housekeeping.repository.ServiceBookingRepository;
+import com.example.housekeeping.repository.ServiceItemRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class BookingService {
+
+    private final ServiceBookingRepository bookingRepository;
+    private final ServiceItemRepository serviceItemRepository;
+
+    public BookingService(ServiceBookingRepository bookingRepository, ServiceItemRepository serviceItemRepository) {
+        this.bookingRepository = bookingRepository;
+        this.serviceItemRepository = serviceItemRepository;
+    }
+
+    public List<ServiceBooking> findAll() {
+        return bookingRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    public List<ServiceBooking> findMyBookings(String username) {
+        return bookingRepository.findByCreatedByOrderByCreatedAtDesc(username);
+    }
+
+    public List<ServiceBooking> findAssignedBookings(String provider) {
+        return bookingRepository.findByAssignedProviderOrderByCreatedAtDesc(provider);
+    }
+
+    @Transactional
+    public ServiceBooking createBooking(String customerName,
+                                        String phone,
+                                        String address,
+                                        LocalDate serviceDate,
+                                        String notes,
+                                        Long serviceItemId,
+                                        String createdBy) {
+        ServiceItem serviceItem = serviceItemRepository.findById(serviceItemId)
+                .orElseThrow(() -> new IllegalArgumentException("服务项目不存在"));
+
+        ServiceBooking booking = new ServiceBooking();
+        booking.setCustomerName(customerName);
+        booking.setPhone(phone);
+        booking.setAddress(address);
+        booking.setServiceDate(serviceDate);
+        booking.setNotes(notes);
+        booking.setStatus(BookingStatus.PENDING);
+        booking.setCreatedBy(createdBy);
+        booking.setServiceItem(serviceItem);
+        booking.setPrice(serviceItem.getPrice());
+
+        return bookingRepository.save(booking);
+    }
+
+    @Transactional
+    public ServiceBooking updateBooking(Long bookingId,
+                                        String customerName,
+                                        String phone,
+                                        String address,
+                                        LocalDate serviceDate,
+                                        String notes,
+                                        Long serviceItemId,
+                                        String username,
+                                        boolean isAdmin) {
+        ServiceBooking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException("预约不存在"));
+
+        if (!isAdmin && !booking.getCreatedBy().equalsIgnoreCase(username)) {
+            throw new AccessDeniedException("无权修改该预约");
+        }
+
+        booking.setCustomerName(customerName);
+        booking.setPhone(phone);
+        booking.setAddress(address);
+        booking.setServiceDate(serviceDate);
+        booking.setNotes(notes);
+
+        if (serviceItemId != null && !serviceItemId.equals(booking.getServiceItem().getId())) {
+            ServiceItem serviceItem = serviceItemRepository.findById(serviceItemId)
+                    .orElseThrow(() -> new IllegalArgumentException("服务项目不存在"));
+            booking.setServiceItem(serviceItem);
+            booking.setPrice(serviceItem.getPrice());
+        }
+
+        return bookingRepository.save(booking);
+    }
+
+    @Transactional
+    public void deleteBooking(Long bookingId, String username, boolean isAdmin) {
+        ServiceBooking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException("预约不存在"));
+
+        if (!isAdmin && !booking.getCreatedBy().equalsIgnoreCase(username)) {
+            throw new AccessDeniedException("无权删除该预约");
+        }
+
+        bookingRepository.delete(booking);
+    }
+
+    @Transactional
+    public ServiceBooking acceptBooking(Long bookingId, String providerName) {
+        ServiceBooking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException("预约不存在"));
+
+        booking.setAssignedProvider(providerName);
+        booking.setStatus(BookingStatus.ACCEPTED);
+        return bookingRepository.save(booking);
+    }
+}
+

--- a/housekeeping/src/main/java/com/example/housekeeping/service/ServiceItemService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/ServiceItemService.java
@@ -1,0 +1,35 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.model.ServiceItem;
+import com.example.housekeeping.repository.ServiceItemRepository;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ServiceItemService {
+
+    private final ServiceItemRepository serviceItemRepository;
+
+    public ServiceItemService(ServiceItemRepository serviceItemRepository) {
+        this.serviceItemRepository = serviceItemRepository;
+    }
+
+    public List<ServiceItem> findAll() {
+        return serviceItemRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
+    }
+
+    public ServiceItem findById(Long id) {
+        return serviceItemRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("服务项目不存在"));
+    }
+
+    public ServiceItem create(ServiceItem item) {
+        if (serviceItemRepository.existsByNameIgnoreCase(item.getName())) {
+            throw new IllegalArgumentException("服务名称已存在");
+        }
+        return serviceItemRepository.save(item);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add lightweight account, service item and booking entities plus repositories to back the Vue frontend
- implement service, wallet and booking REST controllers with supporting services and JWT-aware auth updates
- seed demo accounts, services and booking data so the UI can render immediately after startup

## Testing
- `mvn -DskipTests compile`

------
https://chatgpt.com/codex/tasks/task_b_68e1ea28e63c832cb587f1f026a80758