### PR TITLE
feat: implement housekeeping backend services

### DIFF
--- a/housekeeping/pom.xml
+++ b/housekeeping/pom.xml
@@ -38,10 +38,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/housekeeping/src/main/java/com/example/housekeeping/config/DataInitializer.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/config/DataInitializer.java
@@ -1,0 +1,166 @@
+package com.example.housekeeping.config;
+
+import com.example.housekeeping.domain.entity.Admin;
+import com.example.housekeeping.domain.entity.CarouselItem;
+import com.example.housekeeping.domain.entity.HomeTip;
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.ServiceCategory;
+import com.example.housekeeping.domain.entity.ServiceProvider;
+import com.example.housekeeping.domain.entity.SystemAnnouncement;
+import com.example.housekeeping.domain.entity.UserAccount;
+import com.example.housekeeping.domain.enums.AnnouncementTarget;
+import com.example.housekeeping.repository.AdminRepository;
+import com.example.housekeeping.repository.CarouselItemRepository;
+import com.example.housekeeping.repository.HomeTipRepository;
+import com.example.housekeeping.repository.HousekeepingServiceRepository;
+import com.example.housekeeping.repository.ServiceCategoryRepository;
+import com.example.housekeeping.repository.ServiceProviderRepository;
+import com.example.housekeeping.repository.SystemAnnouncementRepository;
+import com.example.housekeeping.repository.UserAccountRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!prod")
+public class DataInitializer implements CommandLineRunner {
+
+    private final AdminRepository adminRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final ServiceProviderRepository serviceProviderRepository;
+    private final ServiceCategoryRepository serviceCategoryRepository;
+    private final HousekeepingServiceRepository housekeepingServiceRepository;
+    private final SystemAnnouncementRepository systemAnnouncementRepository;
+    private final HomeTipRepository homeTipRepository;
+    private final CarouselItemRepository carouselItemRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public DataInitializer(AdminRepository adminRepository,
+            UserAccountRepository userAccountRepository,
+            ServiceProviderRepository serviceProviderRepository,
+            ServiceCategoryRepository serviceCategoryRepository,
+            HousekeepingServiceRepository housekeepingServiceRepository,
+            SystemAnnouncementRepository systemAnnouncementRepository,
+            HomeTipRepository homeTipRepository,
+            CarouselItemRepository carouselItemRepository,
+            PasswordEncoder passwordEncoder) {
+        this.adminRepository = adminRepository;
+        this.userAccountRepository = userAccountRepository;
+        this.serviceProviderRepository = serviceProviderRepository;
+        this.serviceCategoryRepository = serviceCategoryRepository;
+        this.housekeepingServiceRepository = housekeepingServiceRepository;
+        this.systemAnnouncementRepository = systemAnnouncementRepository;
+        this.homeTipRepository = homeTipRepository;
+        this.carouselItemRepository = carouselItemRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void run(String... args) {
+        if (adminRepository.count() == 0) {
+            Admin admin = new Admin();
+            admin.setUsername("admin");
+            admin.setPassword(passwordEncoder.encode("admin123"));
+            admin.setFullName("系统管理员");
+            admin.setEnabled(true);
+            admin.setLastLoginAt(LocalDateTime.now());
+            adminRepository.save(admin);
+        }
+
+        if (userAccountRepository.count() == 0) {
+            UserAccount user = new UserAccount();
+            user.setUsername("user");
+            user.setPassword(passwordEncoder.encode("123456"));
+            user.setFullName("测试用户");
+            user.setEmail("user@example.com");
+            user.setPhone("13800000000");
+            user.setBalance(new BigDecimal("200"));
+            userAccountRepository.save(user);
+        }
+
+        if (serviceProviderRepository.count() == 0) {
+            ServiceProvider provider = new ServiceProvider();
+            provider.setUsername("provider");
+            provider.setPassword(passwordEncoder.encode("provider123"));
+            provider.setFullName("金牌保洁员");
+            provider.setPhone("13900000000");
+            provider.setServiceArea("上海市");
+            provider.setSkills("深度保洁, 家电清洗");
+            provider.setCertified(true);
+            provider.setBiography("拥有5年家政服务经验，擅长厨房和卫生间深度清洁");
+            provider.setCompletedOrders(86);
+            provider.setBalance(new BigDecimal("520"));
+            serviceProviderRepository.save(provider);
+        }
+
+        if (serviceCategoryRepository.count() == 0) {
+            ServiceCategory cleaning = new ServiceCategory();
+            cleaning.setName("家庭保洁");
+            cleaning.setDescription("日常家庭清洁服务");
+            cleaning.setSortOrder(1);
+            serviceCategoryRepository.save(cleaning);
+
+            ServiceCategory appliance = new ServiceCategory();
+            appliance.setName("家电清洗");
+            appliance.setDescription("专业家电清洗服务");
+            appliance.setSortOrder(2);
+            serviceCategoryRepository.save(appliance);
+
+            List<HousekeepingService> services = List.of(
+                    createService(cleaning, "日常保洁", new BigDecimal("128"), "2小时日常保洁，提供基础工具"),
+                    createService(cleaning, "开荒保洁", new BigDecimal("398"), "新居开荒保洁，包含厨房、卫生间深度清洁"),
+                    createService(appliance, "空调清洗", new BigDecimal("168"), "挂机/柜机专业拆洗服务")
+            );
+            housekeepingServiceRepository.saveAll(services);
+        }
+
+        if (systemAnnouncementRepository.count() == 0) {
+            SystemAnnouncement announcement = new SystemAnnouncement();
+            announcement.setTitle("欢迎使用家政服务管理平台");
+            announcement.setContent("平台现已上线，提供便捷的家政预约、服务管理和数据统计功能。");
+            announcement.setTarget(AnnouncementTarget.ALL);
+            announcement.setPublishedAt(LocalDateTime.now());
+            announcement.setPublishedBy("系统管理员");
+            announcement.setEnabled(true);
+            announcement.setPinned(true);
+            systemAnnouncementRepository.save(announcement);
+        }
+
+        if (homeTipRepository.count() == 0) {
+            HomeTip tip = new HomeTip();
+            tip.setTitle("厨房清洁小窍门");
+            tip.setSummary("三步轻松搞定厨房油污");
+            tip.setContent("使用小苏打加白醋可以快速分解油污，喷洒后静置5分钟再擦拭即可。");
+            tip.setFeatured(true);
+            homeTipRepository.save(tip);
+        }
+
+        if (carouselItemRepository.count() == 0) {
+            housekeepingServiceRepository.findAll().stream().findFirst().ifPresent(service -> {
+                CarouselItem item = new CarouselItem();
+                item.setTitle("热销服务推荐");
+                item.setImageUrl("https://placehold.co/1200x400?text=Housekeeping");
+                item.setSortOrder(1);
+                item.setEnabled(true);
+                item.setService(service);
+                carouselItemRepository.save(item);
+            });
+        }
+    }
+
+    private HousekeepingService createService(ServiceCategory category, String title, BigDecimal price, String description) {
+        HousekeepingService service = new HousekeepingService();
+        service.setCategory(category);
+        service.setTitle(title);
+        service.setPrice(price);
+        service.setDescription(description);
+        service.setFeatured(true);
+        service.setCoverImageUrl("https://placehold.co/400x300");
+        service.setOrderCount(10);
+        return service;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/config/WebConfiguration.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/config/WebConfiguration.java
@@ -1,0 +1,41 @@
+package com.example.housekeeping.config;
+
+import java.time.ZoneId;
+import java.util.TimeZone;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(false)
+                        .maxAge(3600);
+            }
+        };
+    }
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+        return builder -> builder.simpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+                .timeZone(TimeZone.getTimeZone(ZoneId.systemDefault()));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/AdminManagementController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/AdminManagementController.java
@@ -1,0 +1,66 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.Admin;
+import com.example.housekeeping.dto.RegisterRequest;
+import com.example.housekeeping.service.AuthService;
+import com.example.housekeeping.repository.AdminRepository;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/admins")
+public class AdminManagementController {
+
+    private final AdminRepository adminRepository;
+    private final AuthService authService;
+
+    public AdminManagementController(AdminRepository adminRepository, AuthService authService) {
+        this.adminRepository = adminRepository;
+        this.authService = authService;
+    }
+
+    @GetMapping
+    public List<Admin> listAdmins() {
+        return adminRepository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public Admin getAdmin(@PathVariable Long id) {
+        return adminRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "管理员不存在"));
+    }
+
+    @PostMapping
+    public Admin createAdmin(@RequestBody RegisterRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "请求参数不能为空");
+        }
+        RegisterRequest adminRequest = new RegisterRequest(
+                request.username(),
+                request.password(),
+                com.example.housekeeping.domain.enums.RoleType.ADMIN,
+                request.fullName(),
+                request.phone(),
+                request.email(),
+                request.address());
+        authService.register(adminRequest);
+        return adminRepository.findByUsername(adminRequest.username())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "管理员创建失败"));
+    }
+
+    @PutMapping("/{id}/enabled")
+    public Admin updateAdminStatus(@PathVariable Long id, @RequestParam boolean enabled) {
+        Admin admin = getAdmin(id);
+        admin.setEnabled(enabled);
+        return admin;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/AppointmentController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/AppointmentController.java
@@ -1,0 +1,68 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.ServiceAppointment;
+import com.example.housekeeping.dto.AppointmentAssignmentRequest;
+import com.example.housekeeping.dto.AppointmentCreateRequest;
+import com.example.housekeeping.dto.AppointmentStatusUpdateRequest;
+import com.example.housekeeping.service.AppointmentService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PatchMapping;
+
+@RestController
+@RequestMapping("/api/appointments")
+public class AppointmentController {
+
+    private final AppointmentService appointmentService;
+
+    public AppointmentController(AppointmentService appointmentService) {
+        this.appointmentService = appointmentService;
+    }
+
+    @GetMapping
+    public List<ServiceAppointment> listAll() {
+        return appointmentService.getAllAppointments();
+    }
+
+    @GetMapping("/{id}")
+    public ServiceAppointment getById(@PathVariable Long id) {
+        return appointmentService.getAppointment(id);
+    }
+
+    @GetMapping("/user/{userId}")
+    public List<ServiceAppointment> getByUser(@PathVariable Long userId) {
+        return appointmentService.getAppointmentsForUser(userId);
+    }
+
+    @GetMapping("/provider/{providerId}")
+    public List<ServiceAppointment> getByProvider(@PathVariable Long providerId) {
+        return appointmentService.getAppointmentsForProvider(providerId);
+    }
+
+    @PostMapping("/user/{userId}")
+    public ServiceAppointment createAppointment(@PathVariable Long userId,
+            @Valid @RequestBody AppointmentCreateRequest request) {
+        return appointmentService.createAppointment(userId, request);
+    }
+
+    @PostMapping("/{appointmentId}/assign")
+    public ServiceAppointment assignProvider(@PathVariable Long appointmentId,
+            @Valid @RequestBody AppointmentAssignmentRequest request,
+            @RequestParam(name = "adminName", defaultValue = "系统管理员") String adminName) {
+        return appointmentService.assignProvider(appointmentId, request, adminName);
+    }
+
+    @PatchMapping("/{appointmentId}/status")
+    public ServiceAppointment updateStatus(@PathVariable Long appointmentId,
+            @Valid @RequestBody AppointmentStatusUpdateRequest request,
+            @RequestParam(name = "actor", defaultValue = "系统用户") String actor) {
+        return appointmentService.updateStatus(appointmentId, request, actor);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/AuthController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/AuthController.java
@@ -1,0 +1,60 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.enums.RoleType;
+import com.example.housekeeping.dto.AuthRequest;
+import com.example.housekeeping.dto.AuthResponse;
+import com.example.housekeeping.dto.RegisterRequest;
+import com.example.housekeeping.dto.UpdatePasswordRequest;
+import com.example.housekeeping.dto.UpdateProfileRequest;
+import com.example.housekeeping.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public AuthResponse login(@Valid @RequestBody AuthRequest request) {
+        return authService.login(request);
+    }
+
+    @PostMapping("/register")
+    public AuthResponse register(@Valid @RequestBody RegisterRequest request) {
+        return authService.register(request);
+    }
+
+    @PutMapping("/{role}/{id}/password")
+    public void updatePassword(@PathVariable("role") String role,
+            @PathVariable("id") Long id,
+            @Valid @RequestBody UpdatePasswordRequest request) {
+        authService.updatePassword(resolveRole(role), id, request);
+    }
+
+    @PutMapping("/{role}/{id}/profile")
+    public void updateProfile(@PathVariable("role") String role,
+            @PathVariable("id") Long id,
+            @RequestBody UpdateProfileRequest request) {
+        authService.updateProfile(resolveRole(role), id, request);
+    }
+
+    private RoleType resolveRole(String role) {
+        try {
+            return RoleType.valueOf(role.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.BAD_REQUEST, "未知的角色类型: " + role);
+        }
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/CatalogController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/CatalogController.java
@@ -1,0 +1,78 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.ServiceCategory;
+import com.example.housekeeping.dto.HousekeepingServiceRequest;
+import com.example.housekeeping.dto.ServiceCategoryRequest;
+import com.example.housekeeping.service.HousekeepingCatalogService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/catalog")
+public class CatalogController {
+
+    private final HousekeepingCatalogService catalogService;
+
+    public CatalogController(HousekeepingCatalogService catalogService) {
+        this.catalogService = catalogService;
+    }
+
+    @GetMapping("/categories")
+    public List<ServiceCategory> listCategories() {
+        return catalogService.listCategories();
+    }
+
+    @PostMapping("/categories")
+    public ServiceCategory createCategory(@Valid @RequestBody ServiceCategoryRequest request) {
+        return catalogService.createCategory(request);
+    }
+
+    @PutMapping("/categories/{id}")
+    public ServiceCategory updateCategory(@PathVariable Long id, @Valid @RequestBody ServiceCategoryRequest request) {
+        return catalogService.updateCategory(id, request);
+    }
+
+    @DeleteMapping("/categories/{id}")
+    public void deleteCategory(@PathVariable Long id) {
+        catalogService.deleteCategory(id);
+    }
+
+    @GetMapping("/services")
+    public List<HousekeepingService> listServices() {
+        return catalogService.listServices();
+    }
+
+    @GetMapping("/categories/{categoryId}/services")
+    public List<HousekeepingService> listServicesByCategory(@PathVariable Long categoryId) {
+        return catalogService.listServicesByCategory(categoryId);
+    }
+
+    @GetMapping("/services/featured")
+    public List<HousekeepingService> listFeaturedServices() {
+        return catalogService.listFeaturedServices();
+    }
+
+    @PostMapping("/services")
+    public HousekeepingService createService(@Valid @RequestBody HousekeepingServiceRequest request) {
+        return catalogService.createService(request);
+    }
+
+    @PutMapping("/services/{id}")
+    public HousekeepingService updateService(@PathVariable Long id, @Valid @RequestBody HousekeepingServiceRequest request) {
+        return catalogService.updateService(id, request);
+    }
+
+    @DeleteMapping("/services/{id}")
+    public void deleteService(@PathVariable Long id) {
+        catalogService.deleteService(id);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/CertificationController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/CertificationController.java
@@ -1,0 +1,50 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.ProviderCertification;
+import com.example.housekeeping.domain.enums.CertificationStatus;
+import com.example.housekeeping.dto.CertificationReviewRequest;
+import com.example.housekeeping.dto.CertificationSubmissionRequest;
+import com.example.housekeeping.service.CertificationService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/certifications")
+public class CertificationController {
+
+    private final CertificationService certificationService;
+
+    public CertificationController(CertificationService certificationService) {
+        this.certificationService = certificationService;
+    }
+
+    @PostMapping("/provider/{providerId}")
+    public ProviderCertification submitCertification(@PathVariable Long providerId,
+            @Valid @RequestBody CertificationSubmissionRequest request) {
+        return certificationService.submitCertification(providerId, request);
+    }
+
+    @PatchMapping("/{certificationId}")
+    public ProviderCertification reviewCertification(@PathVariable Long certificationId,
+            @Valid @RequestBody CertificationReviewRequest request) {
+        return certificationService.reviewCertification(certificationId, request);
+    }
+
+    @GetMapping
+    public List<ProviderCertification> listCertifications(@RequestParam(required = false) CertificationStatus status) {
+        return certificationService.listCertifications(status);
+    }
+
+    @GetMapping("/provider/{providerId}/latest")
+    public ProviderCertification latestCertification(@PathVariable Long providerId) {
+        return certificationService.latestCertification(providerId);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/ContentController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/ContentController.java
@@ -1,0 +1,188 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.CarouselItem;
+import com.example.housekeeping.domain.entity.HomeTip;
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.SystemAnnouncement;
+import com.example.housekeeping.domain.enums.AnnouncementTarget;
+import com.example.housekeeping.dto.AnnouncementRequest;
+import com.example.housekeeping.dto.CarouselRequest;
+import com.example.housekeeping.dto.HomeTipRequest;
+import com.example.housekeeping.repository.CarouselItemRepository;
+import com.example.housekeeping.repository.HomeTipRepository;
+import com.example.housekeeping.repository.HousekeepingServiceRepository;
+import com.example.housekeeping.repository.SystemAnnouncementRepository;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/content")
+public class ContentController {
+
+    private final SystemAnnouncementRepository systemAnnouncementRepository;
+    private final HomeTipRepository homeTipRepository;
+    private final CarouselItemRepository carouselItemRepository;
+    private final HousekeepingServiceRepository housekeepingServiceRepository;
+
+    public ContentController(SystemAnnouncementRepository systemAnnouncementRepository,
+            HomeTipRepository homeTipRepository,
+            CarouselItemRepository carouselItemRepository,
+            HousekeepingServiceRepository housekeepingServiceRepository) {
+        this.systemAnnouncementRepository = systemAnnouncementRepository;
+        this.homeTipRepository = homeTipRepository;
+        this.carouselItemRepository = carouselItemRepository;
+        this.housekeepingServiceRepository = housekeepingServiceRepository;
+    }
+
+    // Announcements
+    @GetMapping("/announcements")
+    public List<SystemAnnouncement> listAnnouncements(
+            @RequestParam(name = "target", required = false) AnnouncementTarget target,
+            @RequestParam(name = "enabled", defaultValue = "false") boolean onlyEnabled) {
+        if (onlyEnabled) {
+            if (target != null && target != AnnouncementTarget.ALL) {
+                return systemAnnouncementRepository.findByTargetOrTargetOrderByPinnedDescPublishedAtDesc(target, AnnouncementTarget.ALL);
+            }
+            return systemAnnouncementRepository.findByEnabledTrueOrderByPinnedDescPublishedAtDesc();
+        }
+        return systemAnnouncementRepository.findAll();
+    }
+
+    @PostMapping("/announcements")
+    public SystemAnnouncement createAnnouncement(@Valid @RequestBody AnnouncementRequest request) {
+        SystemAnnouncement announcement = new SystemAnnouncement();
+        applyAnnouncement(request, announcement);
+        return systemAnnouncementRepository.save(announcement);
+    }
+
+    @PutMapping("/announcements/{id}")
+    public SystemAnnouncement updateAnnouncement(@PathVariable Long id, @Valid @RequestBody AnnouncementRequest request) {
+        SystemAnnouncement announcement = systemAnnouncementRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "公告不存在"));
+        applyAnnouncement(request, announcement);
+        return announcement;
+    }
+
+    @DeleteMapping("/announcements/{id}")
+    public void deleteAnnouncement(@PathVariable Long id) {
+        if (!systemAnnouncementRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "公告不存在");
+        }
+        systemAnnouncementRepository.deleteById(id);
+    }
+
+    private void applyAnnouncement(AnnouncementRequest request, SystemAnnouncement announcement) {
+        announcement.setTitle(request.title());
+        announcement.setContent(request.content());
+        announcement.setTarget(request.target());
+        announcement.setPinned(request.pinned());
+        announcement.setEnabled(request.enabled());
+        announcement.setPublishedBy(request.publishedBy());
+        if (request.enabled()) {
+            announcement.setPublishedAt(LocalDateTime.now());
+        }
+    }
+
+    // Tips
+    @GetMapping("/tips")
+    public List<HomeTip> listTips() {
+        return homeTipRepository.findAll();
+    }
+
+    @GetMapping("/tips/featured")
+    public List<HomeTip> listFeaturedTips() {
+        return homeTipRepository.findByFeaturedTrueOrderByUpdatedAtDesc();
+    }
+
+    @PostMapping("/tips")
+    public HomeTip createTip(@Valid @RequestBody HomeTipRequest request) {
+        HomeTip tip = new HomeTip();
+        applyTip(request, tip);
+        return homeTipRepository.save(tip);
+    }
+
+    @PutMapping("/tips/{id}")
+    public HomeTip updateTip(@PathVariable Long id, @Valid @RequestBody HomeTipRequest request) {
+        HomeTip tip = homeTipRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "居家贴士不存在"));
+        applyTip(request, tip);
+        return tip;
+    }
+
+    @DeleteMapping("/tips/{id}")
+    public void deleteTip(@PathVariable Long id) {
+        if (!homeTipRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "居家贴士不存在");
+        }
+        homeTipRepository.deleteById(id);
+    }
+
+    private void applyTip(HomeTipRequest request, HomeTip tip) {
+        tip.setTitle(request.title());
+        tip.setSummary(request.summary());
+        tip.setContent(request.content());
+        tip.setCoverImageUrl(request.coverImageUrl());
+        tip.setFeatured(request.featured());
+    }
+
+    // Carousel
+    @GetMapping("/carousel")
+    public List<CarouselItem> listCarousel() {
+        return carouselItemRepository.findAll();
+    }
+
+    @GetMapping("/carousel/active")
+    public List<CarouselItem> listActiveCarousel() {
+        return carouselItemRepository.findByEnabledTrueOrderBySortOrderAsc();
+    }
+
+    @PostMapping("/carousel")
+    public CarouselItem createCarousel(@Valid @RequestBody CarouselRequest request) {
+        CarouselItem item = new CarouselItem();
+        applyCarousel(request, item);
+        return carouselItemRepository.save(item);
+    }
+
+    @PutMapping("/carousel/{id}")
+    public CarouselItem updateCarousel(@PathVariable Long id, @Valid @RequestBody CarouselRequest request) {
+        CarouselItem item = carouselItemRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "轮播图不存在"));
+        applyCarousel(request, item);
+        return item;
+    }
+
+    @DeleteMapping("/carousel/{id}")
+    public void deleteCarousel(@PathVariable Long id) {
+        if (!carouselItemRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "轮播图不存在");
+        }
+        carouselItemRepository.deleteById(id);
+    }
+
+    private void applyCarousel(CarouselRequest request, CarouselItem item) {
+        item.setTitle(request.title());
+        item.setImageUrl(request.imageUrl());
+        item.setLinkUrl(request.linkUrl());
+        item.setSortOrder(request.sortOrder());
+        item.setEnabled(request.enabled());
+        if (request.serviceId() != null) {
+            HousekeepingService service = housekeepingServiceRepository.findById(request.serviceId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "关联服务不存在"));
+            item.setService(service);
+        } else {
+            item.setService(null);
+        }
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/DashboardController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/DashboardController.java
@@ -1,0 +1,23 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.dto.DashboardStatsResponse;
+import com.example.housekeeping.service.DashboardService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping("/stats")
+    public DashboardStatsResponse loadStats() {
+        return dashboardService.loadDashboardStats();
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/FavoriteController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/FavoriteController.java
@@ -1,0 +1,37 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.FavoriteService;
+import com.example.housekeeping.service.FavoriteServiceManager;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/favorites")
+public class FavoriteController {
+
+    private final FavoriteServiceManager favoriteServiceManager;
+
+    public FavoriteController(FavoriteServiceManager favoriteServiceManager) {
+        this.favoriteServiceManager = favoriteServiceManager;
+    }
+
+    @PostMapping("/user/{userId}/service/{serviceId}")
+    public FavoriteService addFavorite(@PathVariable Long userId, @PathVariable Long serviceId) {
+        return favoriteServiceManager.addFavorite(userId, serviceId);
+    }
+
+    @DeleteMapping("/user/{userId}/service/{serviceId}")
+    public void removeFavorite(@PathVariable Long userId, @PathVariable Long serviceId) {
+        favoriteServiceManager.removeFavorite(userId, serviceId);
+    }
+
+    @GetMapping("/user/{userId}")
+    public List<FavoriteService> listFavorites(@PathVariable Long userId) {
+        return favoriteServiceManager.getFavoritesForUser(userId);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/FinanceController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/FinanceController.java
@@ -1,0 +1,64 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.RechargeRecord;
+import com.example.housekeeping.domain.entity.WithdrawalRecord;
+import com.example.housekeeping.dto.RechargeRequest;
+import com.example.housekeeping.dto.WithdrawalProcessRequest;
+import com.example.housekeeping.dto.WithdrawalRequest;
+import com.example.housekeeping.service.FinanceService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/finance")
+public class FinanceController {
+
+    private final FinanceService financeService;
+
+    public FinanceController(FinanceService financeService) {
+        this.financeService = financeService;
+    }
+
+    @PostMapping("/recharge/user/{userId}")
+    public RechargeRecord createRecharge(@PathVariable Long userId, @Valid @RequestBody RechargeRequest request) {
+        return financeService.createRecharge(userId, request);
+    }
+
+    @GetMapping("/recharge/user/{userId}")
+    public List<RechargeRecord> getUserRecharges(@PathVariable Long userId) {
+        return financeService.getRechargesForUser(userId);
+    }
+
+    @GetMapping("/recharge")
+    public List<RechargeRecord> getAllRecharges() {
+        return financeService.getAllRecharges();
+    }
+
+    @PostMapping("/withdraw/provider/{providerId}")
+    public WithdrawalRecord requestWithdrawal(@PathVariable Long providerId, @Valid @RequestBody WithdrawalRequest request) {
+        return financeService.requestWithdrawal(providerId, request);
+    }
+
+    @PatchMapping("/withdraw/{withdrawalId}")
+    public WithdrawalRecord processWithdrawal(@PathVariable Long withdrawalId,
+            @Valid @RequestBody WithdrawalProcessRequest request) {
+        return financeService.processWithdrawal(withdrawalId, request);
+    }
+
+    @GetMapping("/withdraw/provider/{providerId}")
+    public List<WithdrawalRecord> getProviderWithdrawals(@PathVariable Long providerId) {
+        return financeService.getWithdrawalsForProvider(providerId);
+    }
+
+    @GetMapping("/withdraw")
+    public List<WithdrawalRecord> getAllWithdrawals() {
+        return financeService.getAllWithdrawals();
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/GlobalExceptionHandler.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/GlobalExceptionHandler.java
@@ -1,0 +1,76 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatus(ResponseStatusException ex, HttpServletRequest request) {
+        HttpStatusCode statusCode = ex.getStatusCode();
+        HttpStatus httpStatus = HttpStatus.resolve(statusCode.value());
+        String error = httpStatus != null ? httpStatus.getReasonPhrase() : statusCode.toString();
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                statusCode.value(),
+                error,
+                ex.getReason(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(statusCode).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .orElse("参数校验失败");
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                message,
+                request.getRequestURI()
+        );
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex, HttpServletRequest request) {
+        String message = ex.getConstraintViolations().stream()
+                .findFirst()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .orElse(ex.getMessage());
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                message,
+                request.getRequestURI()
+        );
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneral(Exception ex, HttpServletRequest request) {
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/ProviderManagementController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/ProviderManagementController.java
@@ -1,0 +1,49 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.ServiceProvider;
+import com.example.housekeeping.repository.ServiceProviderRepository;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/providers")
+public class ProviderManagementController {
+
+    private final ServiceProviderRepository serviceProviderRepository;
+
+    public ProviderManagementController(ServiceProviderRepository serviceProviderRepository) {
+        this.serviceProviderRepository = serviceProviderRepository;
+    }
+
+    @GetMapping
+    public List<ServiceProvider> listProviders() {
+        return serviceProviderRepository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ServiceProvider getProvider(@PathVariable Long id) {
+        return serviceProviderRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "家政人员不存在"));
+    }
+
+    @PutMapping("/{id}/enabled")
+    public ServiceProvider updateProviderStatus(@PathVariable Long id, @RequestParam boolean enabled) {
+        ServiceProvider provider = getProvider(id);
+        provider.setEnabled(enabled);
+        return provider;
+    }
+
+    @PutMapping("/{id}/certified")
+    public ServiceProvider updateCertified(@PathVariable Long id, @RequestParam boolean certified) {
+        ServiceProvider provider = getProvider(id);
+        provider.setCertified(certified);
+        return provider;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/ReviewController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/ReviewController.java
@@ -1,0 +1,53 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.ServiceReview;
+import com.example.housekeeping.dto.ReviewReplyRequest;
+import com.example.housekeeping.dto.ServiceReviewRequest;
+import com.example.housekeeping.service.ReviewService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PostMapping("/user/{userId}")
+    public ServiceReview submitReview(@PathVariable Long userId, @Valid @RequestBody ServiceReviewRequest request) {
+        return reviewService.submitReview(userId, request);
+    }
+
+    @PostMapping("/{reviewId}/reply")
+    public ServiceReview replyReview(@PathVariable Long reviewId,
+            @RequestParam Long providerId,
+            @Valid @RequestBody ReviewReplyRequest request) {
+        return reviewService.replyReview(reviewId, request, providerId);
+    }
+
+    @GetMapping("/service/{serviceId}")
+    public List<ServiceReview> getServiceReviews(@PathVariable Long serviceId) {
+        return reviewService.getReviewsForService(serviceId);
+    }
+
+    @GetMapping("/provider/{providerId}")
+    public List<ServiceReview> getProviderReviews(@PathVariable Long providerId) {
+        return reviewService.getReviewsForProvider(providerId);
+    }
+
+    @GetMapping("/user/{userId}")
+    public List<ServiceReview> getUserReviews(@PathVariable Long userId) {
+        return reviewService.getReviewsForUser(userId);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/UserManagementController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/UserManagementController.java
@@ -1,0 +1,51 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.domain.entity.UserAccount;
+import com.example.housekeeping.repository.UserAccountRepository;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserManagementController {
+
+    private final UserAccountRepository userAccountRepository;
+
+    public UserManagementController(UserAccountRepository userAccountRepository) {
+        this.userAccountRepository = userAccountRepository;
+    }
+
+    @GetMapping
+    public List<UserAccount> listUsers() {
+        return userAccountRepository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public UserAccount getUser(@PathVariable Long id) {
+        return userAccountRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "用户不存在"));
+    }
+
+    @PutMapping("/{id}/enabled")
+    public UserAccount updateUserStatus(@PathVariable Long id, @RequestParam boolean enabled) {
+        UserAccount user = getUser(id);
+        user.setEnabled(enabled);
+        return user;
+    }
+
+    @PutMapping("/{id}/balance")
+    public UserAccount adjustBalance(@PathVariable Long id, @RequestParam @NotNull BigDecimal balance) {
+        UserAccount user = getUser(id);
+        user.setBalance(balance);
+        return user;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/Admin.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/Admin.java
@@ -1,0 +1,34 @@
+package com.example.housekeeping.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "admins")
+public class Admin extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String fullName;
+
+    private String phone;
+
+    private String email;
+
+    private String avatarUrl;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    private LocalDateTime lastLoginAt;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/BaseEntity.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/BaseEntity.java
@@ -1,0 +1,55 @@
+package com.example.housekeeping.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@MappedSuperclass
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/CarouselItem.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/CarouselItem.java
@@ -1,0 +1,35 @@
+package com.example.housekeeping.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "carousel_items")
+public class CarouselItem extends BaseEntity {
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    private String linkUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "service_id")
+    private HousekeepingService service;
+
+    @Column(nullable = false)
+    private Integer sortOrder = 0;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/FavoriteService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/FavoriteService.java
@@ -1,0 +1,27 @@
+package com.example.housekeeping.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "favorite_services", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "service_id"})
+})
+public class FavoriteService extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "service_id")
+    private HousekeepingService service;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/HomeTip.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/HomeTip.java
@@ -1,0 +1,33 @@
+package com.example.housekeeping.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "home_tips")
+public class HomeTip extends BaseEntity {
+
+    @Column(nullable = false)
+    private String title;
+
+    private String summary;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private String coverImageUrl;
+
+    @Column(nullable = false)
+    private boolean featured = false;
+
+    @Column(nullable = false)
+    private Integer viewCount = 0;
+
+    @Column(nullable = false)
+    private Integer likeCount = 0;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/HousekeepingService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/HousekeepingService.java
@@ -1,0 +1,48 @@
+package com.example.housekeeping.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "housekeeping_services")
+public class HousekeepingService extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private ServiceCategory category;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+
+    private Integer durationMinutes;
+
+    private Double rating;
+
+    @Column(nullable = false)
+    private Integer orderCount = 0;
+
+    @Column(nullable = false)
+    private boolean featured = false;
+
+    private String coverImageUrl;
+
+    private String tags;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ProviderCertification.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ProviderCertification.java
@@ -1,0 +1,44 @@
+package com.example.housekeeping.domain.entity;
+
+import com.example.housekeeping.domain.enums.CertificationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "provider_certifications")
+public class ProviderCertification extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "provider_id")
+    private ServiceProvider provider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CertificationStatus status = CertificationStatus.PENDING;
+
+    @Column(columnDefinition = "TEXT")
+    private String documents;
+
+    private String experienceYears;
+
+    private String speciality;
+
+    private String auditRemark;
+
+    private String reviewedBy;
+
+    private LocalDateTime submittedAt;
+
+    private LocalDateTime reviewedAt;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/RechargeRecord.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/RechargeRecord.java
@@ -1,0 +1,41 @@
+package com.example.housekeeping.domain.entity;
+
+import com.example.housekeeping.domain.enums.PaymentStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "recharge_records")
+public class RechargeRecord extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    private String paymentMethod;
+
+    private String referenceNo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status = PaymentStatus.PENDING;
+
+    private LocalDateTime paidAt;
+
+    private String remark;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ServiceAppointment.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ServiceAppointment.java
@@ -1,0 +1,63 @@
+package com.example.housekeeping.domain.entity;
+
+import com.example.housekeeping.domain.enums.AppointmentStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "service_appointments")
+public class ServiceAppointment extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "service_id")
+    private HousekeepingService service;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "provider_id")
+    private ServiceProvider provider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AppointmentStatus status = AppointmentStatus.PENDING_REVIEW;
+
+    private LocalDateTime scheduledAt;
+
+    private LocalDateTime actualStartAt;
+
+    private LocalDateTime actualEndAt;
+
+    private String address;
+
+    private String contactName;
+
+    private String contactPhone;
+
+    private String userNotes;
+
+    private String adminNotes;
+
+    private String auditRemark;
+
+    private String auditBy;
+
+    private LocalDateTime auditAt;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ServiceCategory.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ServiceCategory.java
@@ -1,0 +1,27 @@
+package com.example.housekeeping.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "service_categories")
+public class ServiceCategory extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    private String description;
+
+    private String iconUrl;
+
+    @Column(nullable = false)
+    private Integer sortOrder = 0;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ServiceProvider.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ServiceProvider.java
@@ -1,0 +1,61 @@
+package com.example.housekeeping.domain.entity;
+
+import com.example.housekeeping.domain.enums.RoleType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "service_providers")
+public class ServiceProvider extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String fullName;
+
+    private String phone;
+
+    private String email;
+
+    private String idNumber;
+
+    private String serviceArea;
+
+    private String skills;
+
+    private String biography;
+
+    private String avatarUrl;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    @Column(nullable = false)
+    private boolean certified = false;
+
+    private Double rating;
+
+    @Column(nullable = false)
+    private Integer completedOrders = 0;
+
+    @Column(nullable = false)
+    private BigDecimal balance = BigDecimal.ZERO;
+
+    private LocalDateTime lastLoginAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RoleType role = RoleType.PROVIDER;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ServiceReview.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/ServiceReview.java
@@ -1,0 +1,45 @@
+package com.example.housekeeping.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "service_reviews")
+public class ServiceReview extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "appointment_id", unique = true)
+    private ServiceAppointment appointment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserAccount user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "provider_id")
+    private ServiceProvider provider;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "service_id")
+    private HousekeepingService service;
+
+    @Column(nullable = false)
+    private Integer rating;
+
+    @Column(columnDefinition = "TEXT")
+    private String comment;
+
+    private String reply;
+
+    private LocalDateTime repliedAt;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/SystemAnnouncement.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/SystemAnnouncement.java
@@ -1,0 +1,38 @@
+package com.example.housekeeping.domain.entity;
+
+import com.example.housekeeping.domain.enums.AnnouncementTarget;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "system_announcements")
+public class SystemAnnouncement extends BaseEntity {
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnnouncementTarget target = AnnouncementTarget.ALL;
+
+    private String publishedBy;
+
+    private LocalDateTime publishedAt;
+
+    @Column(nullable = false)
+    private boolean pinned = false;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/UserAccount.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/UserAccount.java
@@ -1,0 +1,53 @@
+package com.example.housekeeping.domain.entity;
+
+import com.example.housekeeping.domain.enums.RoleType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "users")
+public class UserAccount extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String fullName;
+
+    private String phone;
+
+    private String email;
+
+    private String address;
+
+    private String avatarUrl;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    @Column(nullable = false)
+    private boolean verified = false;
+
+    @Column(nullable = false)
+    private BigDecimal balance = BigDecimal.ZERO;
+
+    @Column(nullable = false)
+    private Integer points = 0;
+
+    private LocalDateTime lastLoginAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RoleType role = RoleType.USER;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/entity/WithdrawalRecord.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/entity/WithdrawalRecord.java
@@ -1,0 +1,43 @@
+package com.example.housekeeping.domain.entity;
+
+import com.example.housekeeping.domain.enums.WithdrawalStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "withdrawal_records")
+public class WithdrawalRecord extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "provider_id")
+    private ServiceProvider provider;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    private String accountInfo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private WithdrawalStatus status = WithdrawalStatus.PENDING;
+
+    private LocalDateTime requestedAt;
+
+    private LocalDateTime processedAt;
+
+    private String remark;
+
+    private String processedBy;
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/enums/AnnouncementTarget.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/enums/AnnouncementTarget.java
@@ -1,0 +1,8 @@
+package com.example.housekeeping.domain.enums;
+
+public enum AnnouncementTarget {
+    ALL,
+    USERS,
+    PROVIDERS,
+    ADMINS
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/enums/AppointmentStatus.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/enums/AppointmentStatus.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.domain.enums;
+
+public enum AppointmentStatus {
+    PENDING_REVIEW,
+    APPROVED,
+    REJECTED,
+    ASSIGNED,
+    IN_SERVICE,
+    COMPLETED,
+    CANCELLED
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/enums/CertificationStatus.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/enums/CertificationStatus.java
@@ -1,0 +1,7 @@
+package com.example.housekeeping.domain.enums;
+
+public enum CertificationStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/enums/PaymentStatus.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/enums/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.example.housekeeping.domain.enums;
+
+public enum PaymentStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/enums/RoleType.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/enums/RoleType.java
@@ -1,0 +1,7 @@
+package com.example.housekeeping.domain.enums;
+
+public enum RoleType {
+    ADMIN,
+    USER,
+    PROVIDER
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/domain/enums/WithdrawalStatus.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/domain/enums/WithdrawalStatus.java
@@ -1,0 +1,8 @@
+package com.example.housekeeping.domain.enums;
+
+public enum WithdrawalStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    PAID
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/AnnouncementRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/AnnouncementRequest.java
@@ -1,0 +1,14 @@
+package com.example.housekeeping.dto;
+
+import com.example.housekeeping.domain.enums.AnnouncementTarget;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AnnouncementRequest(
+        @NotBlank String title,
+        @NotBlank String content,
+        @NotNull AnnouncementTarget target,
+        boolean pinned,
+        boolean enabled,
+        String publishedBy
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/AppointmentAssignmentRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/AppointmentAssignmentRequest.java
@@ -1,0 +1,8 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AppointmentAssignmentRequest(
+        @NotNull Long providerId,
+        String adminNotes
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/AppointmentCreateRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/AppointmentCreateRequest.java
@@ -1,0 +1,17 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record AppointmentCreateRequest(
+        @NotNull Long serviceId,
+        @NotNull @FutureOrPresent LocalDateTime scheduledAt,
+        @NotBlank String address,
+        @NotBlank String contactName,
+        @NotBlank String contactPhone,
+        BigDecimal price,
+        String userNotes
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/AppointmentStatusUpdateRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/AppointmentStatusUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.example.housekeeping.dto;
+
+import com.example.housekeeping.domain.enums.AppointmentStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record AppointmentStatusUpdateRequest(
+        @NotNull AppointmentStatus status,
+        String remark
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/AuthRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/AuthRequest.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.dto;
+
+import com.example.housekeeping.domain.enums.RoleType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AuthRequest(
+        @NotBlank String username,
+        @NotBlank String password,
+        @NotNull RoleType role
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/AuthResponse.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/AuthResponse.java
@@ -1,0 +1,12 @@
+package com.example.housekeeping.dto;
+
+import com.example.housekeeping.domain.enums.RoleType;
+import java.time.LocalDateTime;
+
+public record AuthResponse(
+        Long id,
+        RoleType role,
+        String username,
+        String displayName,
+        LocalDateTime loginTime
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/CarouselRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/CarouselRequest.java
@@ -1,0 +1,13 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CarouselRequest(
+        @NotBlank String title,
+        @NotBlank String imageUrl,
+        String linkUrl,
+        Long serviceId,
+        @NotNull Integer sortOrder,
+        boolean enabled
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/CertificationReviewRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/CertificationReviewRequest.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.dto;
+
+import com.example.housekeeping.domain.enums.CertificationStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CertificationReviewRequest(
+        @NotNull CertificationStatus status,
+        @NotBlank String reviewedBy,
+        String remark
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/CertificationSubmissionRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/CertificationSubmissionRequest.java
@@ -1,0 +1,9 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CertificationSubmissionRequest(
+        @NotBlank String documents,
+        String experienceYears,
+        String speciality
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/DashboardStatsResponse.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/DashboardStatsResponse.java
@@ -1,0 +1,24 @@
+package com.example.housekeeping.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record DashboardStatsResponse(
+        long totalUsers,
+        long totalProviders,
+        long totalServices,
+        long totalAppointments,
+        long pendingAppointments,
+        long pendingCertifications,
+        long totalRecharges,
+        long totalWithdrawals,
+        BigDecimal rechargeSum,
+        BigDecimal withdrawalSum,
+        List<TrendPoint> rechargeTrend,
+        List<TrendPoint> appointmentTrend,
+        List<CategoryCount> serviceCategoryDistribution
+) {
+    public record TrendPoint(String label, Number value) {}
+
+    public record CategoryCount(String label, Number value) {}
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/ErrorResponse.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.dto;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+        LocalDateTime timestamp,
+        int status,
+        String error,
+        String message,
+        String path
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/HomeTipRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/HomeTipRequest.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record HomeTipRequest(
+        @NotBlank String title,
+        String summary,
+        String content,
+        String coverImageUrl,
+        boolean featured
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/HousekeepingServiceRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/HousekeepingServiceRequest.java
@@ -1,0 +1,18 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+public record HousekeepingServiceRequest(
+        @NotNull Long categoryId,
+        @NotBlank String title,
+        String description,
+        @NotNull @Positive BigDecimal price,
+        Integer durationMinutes,
+        boolean featured,
+        String coverImageUrl,
+        String tags,
+        boolean enabled
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/RechargeRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/RechargeRequest.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+public record RechargeRequest(
+        @NotNull @Positive BigDecimal amount,
+        @NotBlank String paymentMethod
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/RegisterRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/RegisterRequest.java
@@ -1,0 +1,15 @@
+package com.example.housekeeping.dto;
+
+import com.example.housekeeping.domain.enums.RoleType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record RegisterRequest(
+        @NotBlank String username,
+        @NotBlank String password,
+        @NotNull RoleType role,
+        String fullName,
+        String phone,
+        String email,
+        String address
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/ReviewReplyRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/ReviewReplyRequest.java
@@ -1,0 +1,7 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReviewReplyRequest(
+        @NotBlank String reply
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/ServiceCategoryRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/ServiceCategoryRequest.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ServiceCategoryRequest(
+        @NotBlank String name,
+        String description,
+        String iconUrl,
+        Integer sortOrder,
+        boolean enabled
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/ServiceReviewRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/ServiceReviewRequest.java
@@ -1,0 +1,12 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ServiceReviewRequest(
+        @NotNull Long appointmentId,
+        @NotNull @Min(1) @Max(5) Integer rating,
+        @NotBlank String comment
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/UpdatePasswordRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/UpdatePasswordRequest.java
@@ -1,0 +1,8 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdatePasswordRequest(
+        @NotBlank String oldPassword,
+        @NotBlank String newPassword
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/UpdateProfileRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/UpdateProfileRequest.java
@@ -1,0 +1,12 @@
+package com.example.housekeeping.dto;
+
+public record UpdateProfileRequest(
+        String fullName,
+        String phone,
+        String email,
+        String address,
+        String avatarUrl,
+        String biography,
+        String serviceArea,
+        String skills
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/WithdrawalProcessRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/WithdrawalProcessRequest.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.dto;
+
+import com.example.housekeeping.domain.enums.WithdrawalStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record WithdrawalProcessRequest(
+        @NotNull WithdrawalStatus status,
+        @NotBlank String processedBy,
+        String remark
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/WithdrawalRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/WithdrawalRequest.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+public record WithdrawalRequest(
+        @NotNull @Positive BigDecimal amount,
+        @NotBlank String accountInfo
+) {}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/AdminRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/AdminRepository.java
@@ -1,0 +1,9 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.Admin;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+    Optional<Admin> findByUsername(String username);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/CarouselItemRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/CarouselItemRepository.java
@@ -1,0 +1,9 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.CarouselItem;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CarouselItemRepository extends JpaRepository<CarouselItem, Long> {
+    List<CarouselItem> findByEnabledTrueOrderBySortOrderAsc();
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/FavoriteServiceRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/FavoriteServiceRepository.java
@@ -1,0 +1,12 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.FavoriteService;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteServiceRepository extends JpaRepository<FavoriteService, Long> {
+    List<FavoriteService> findByUserId(Long userId);
+    Optional<FavoriteService> findByUserIdAndServiceId(Long userId, Long serviceId);
+    void deleteByUserIdAndServiceId(Long userId, Long serviceId);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/HomeTipRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/HomeTipRepository.java
@@ -1,0 +1,9 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.HomeTip;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HomeTipRepository extends JpaRepository<HomeTip, Long> {
+    List<HomeTip> findByFeaturedTrueOrderByUpdatedAtDesc();
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/HousekeepingServiceRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/HousekeepingServiceRepository.java
@@ -1,0 +1,10 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HousekeepingServiceRepository extends JpaRepository<HousekeepingService, Long> {
+    List<HousekeepingService> findByCategoryId(Long categoryId);
+    List<HousekeepingService> findByFeaturedTrueOrderByOrderCountDesc();
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ProviderCertificationRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ProviderCertificationRepository.java
@@ -1,0 +1,13 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.ProviderCertification;
+import com.example.housekeeping.domain.enums.CertificationStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProviderCertificationRepository extends JpaRepository<ProviderCertification, Long> {
+    List<ProviderCertification> findByStatus(CertificationStatus status);
+    Optional<ProviderCertification> findTopByProviderIdOrderByCreatedAtDesc(Long providerId);
+    long countByStatus(CertificationStatus status);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/RechargeRecordRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/RechargeRecordRepository.java
@@ -1,0 +1,11 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.RechargeRecord;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RechargeRecordRepository extends JpaRepository<RechargeRecord, Long> {
+    List<RechargeRecord> findByUserIdOrderByCreatedAtDesc(Long userId);
+    List<RechargeRecord> findByPaidAtBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceAppointmentRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceAppointmentRepository.java
@@ -1,0 +1,14 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.ServiceAppointment;
+import com.example.housekeeping.domain.enums.AppointmentStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ServiceAppointmentRepository extends JpaRepository<ServiceAppointment, Long> {
+    List<ServiceAppointment> findByUserIdOrderByCreatedAtDesc(Long userId);
+    List<ServiceAppointment> findByProviderIdOrderByCreatedAtDesc(Long providerId);
+    long countByStatus(AppointmentStatus status);
+    List<ServiceAppointment> findByScheduledAtBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceCategoryRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.ServiceCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ServiceCategoryRepository extends JpaRepository<ServiceCategory, Long> {
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceProviderRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceProviderRepository.java
@@ -1,0 +1,9 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.ServiceProvider;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ServiceProviderRepository extends JpaRepository<ServiceProvider, Long> {
+    Optional<ServiceProvider> findByUsername(String username);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceReviewRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceReviewRepository.java
@@ -1,0 +1,13 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.ServiceReview;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ServiceReviewRepository extends JpaRepository<ServiceReview, Long> {
+    List<ServiceReview> findByProviderId(Long providerId);
+    List<ServiceReview> findByServiceId(Long serviceId);
+    Optional<ServiceReview> findByAppointmentId(Long appointmentId);
+    List<ServiceReview> findByUserId(Long userId);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/SystemAnnouncementRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/SystemAnnouncementRepository.java
@@ -1,0 +1,12 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.SystemAnnouncement;
+import com.example.housekeeping.domain.enums.AnnouncementTarget;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SystemAnnouncementRepository extends JpaRepository<SystemAnnouncement, Long> {
+    List<SystemAnnouncement> findByEnabledTrueOrderByPinnedDescPublishedAtDesc();
+    List<SystemAnnouncement> findByTargetOrTargetOrderByPinnedDescPublishedAtDesc(
+            AnnouncementTarget target, AnnouncementTarget fallback);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/UserAccountRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/UserAccountRepository.java
@@ -1,0 +1,9 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.UserAccount;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+    Optional<UserAccount> findByUsername(String username);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/WithdrawalRecordRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/WithdrawalRecordRepository.java
@@ -1,0 +1,9 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.domain.entity.WithdrawalRecord;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawalRecordRepository extends JpaRepository<WithdrawalRecord, Long> {
+    List<WithdrawalRecord> findByProviderIdOrderByCreatedAtDesc(Long providerId);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/AppointmentService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/AppointmentService.java
@@ -1,0 +1,23 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.domain.entity.ServiceAppointment;
+import com.example.housekeeping.dto.AppointmentAssignmentRequest;
+import com.example.housekeeping.dto.AppointmentCreateRequest;
+import com.example.housekeeping.dto.AppointmentStatusUpdateRequest;
+import java.util.List;
+
+public interface AppointmentService {
+    ServiceAppointment createAppointment(Long userId, AppointmentCreateRequest request);
+
+    ServiceAppointment getAppointment(Long id);
+
+    List<ServiceAppointment> getAppointmentsForUser(Long userId);
+
+    List<ServiceAppointment> getAppointmentsForProvider(Long providerId);
+
+    List<ServiceAppointment> getAllAppointments();
+
+    ServiceAppointment assignProvider(Long appointmentId, AppointmentAssignmentRequest request, String adminName);
+
+    ServiceAppointment updateStatus(Long appointmentId, AppointmentStatusUpdateRequest request, String actor);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/AuthService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/AuthService.java
@@ -1,0 +1,18 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.domain.enums.RoleType;
+import com.example.housekeeping.dto.AuthRequest;
+import com.example.housekeeping.dto.AuthResponse;
+import com.example.housekeeping.dto.RegisterRequest;
+import com.example.housekeeping.dto.UpdatePasswordRequest;
+import com.example.housekeeping.dto.UpdateProfileRequest;
+
+public interface AuthService {
+    AuthResponse login(AuthRequest request);
+
+    AuthResponse register(RegisterRequest request);
+
+    void updatePassword(RoleType role, Long id, UpdatePasswordRequest request);
+
+    void updateProfile(RoleType role, Long id, UpdateProfileRequest request);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/CertificationService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/CertificationService.java
@@ -1,0 +1,17 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.domain.entity.ProviderCertification;
+import com.example.housekeeping.domain.enums.CertificationStatus;
+import com.example.housekeeping.dto.CertificationReviewRequest;
+import com.example.housekeeping.dto.CertificationSubmissionRequest;
+import java.util.List;
+
+public interface CertificationService {
+    ProviderCertification submitCertification(Long providerId, CertificationSubmissionRequest request);
+
+    ProviderCertification reviewCertification(Long certificationId, CertificationReviewRequest request);
+
+    List<ProviderCertification> listCertifications(CertificationStatus status);
+
+    ProviderCertification latestCertification(Long providerId);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/DashboardService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/DashboardService.java
@@ -1,0 +1,7 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.dto.DashboardStatsResponse;
+
+public interface DashboardService {
+    DashboardStatsResponse loadDashboardStats();
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/FavoriteServiceManager.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/FavoriteServiceManager.java
@@ -1,0 +1,12 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.domain.entity.FavoriteService;
+import java.util.List;
+
+public interface FavoriteServiceManager {
+    FavoriteService addFavorite(Long userId, Long serviceId);
+
+    void removeFavorite(Long userId, Long serviceId);
+
+    List<FavoriteService> getFavoritesForUser(Long userId);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/FinanceService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/FinanceService.java
@@ -1,0 +1,24 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.domain.entity.RechargeRecord;
+import com.example.housekeeping.domain.entity.WithdrawalRecord;
+import com.example.housekeeping.dto.RechargeRequest;
+import com.example.housekeeping.dto.WithdrawalProcessRequest;
+import com.example.housekeeping.dto.WithdrawalRequest;
+import java.util.List;
+
+public interface FinanceService {
+    RechargeRecord createRecharge(Long userId, RechargeRequest request);
+
+    List<RechargeRecord> getRechargesForUser(Long userId);
+
+    List<RechargeRecord> getAllRecharges();
+
+    WithdrawalRecord requestWithdrawal(Long providerId, WithdrawalRequest request);
+
+    WithdrawalRecord processWithdrawal(Long withdrawalId, WithdrawalProcessRequest request);
+
+    List<WithdrawalRecord> getWithdrawalsForProvider(Long providerId);
+
+    List<WithdrawalRecord> getAllWithdrawals();
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/HousekeepingCatalogService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/HousekeepingCatalogService.java
@@ -1,0 +1,29 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.ServiceCategory;
+import com.example.housekeeping.dto.HousekeepingServiceRequest;
+import com.example.housekeeping.dto.ServiceCategoryRequest;
+import java.util.List;
+
+public interface HousekeepingCatalogService {
+    List<ServiceCategory> listCategories();
+
+    ServiceCategory createCategory(ServiceCategoryRequest request);
+
+    ServiceCategory updateCategory(Long id, ServiceCategoryRequest request);
+
+    void deleteCategory(Long id);
+
+    List<HousekeepingService> listServices();
+
+    List<HousekeepingService> listServicesByCategory(Long categoryId);
+
+    List<HousekeepingService> listFeaturedServices();
+
+    HousekeepingService createService(HousekeepingServiceRequest request);
+
+    HousekeepingService updateService(Long id, HousekeepingServiceRequest request);
+
+    void deleteService(Long id);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/ReviewService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/ReviewService.java
@@ -1,0 +1,18 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.domain.entity.ServiceReview;
+import com.example.housekeeping.dto.ReviewReplyRequest;
+import com.example.housekeeping.dto.ServiceReviewRequest;
+import java.util.List;
+
+public interface ReviewService {
+    ServiceReview submitReview(Long userId, ServiceReviewRequest request);
+
+    ServiceReview replyReview(Long reviewId, ReviewReplyRequest request, Long providerId);
+
+    List<ServiceReview> getReviewsForService(Long serviceId);
+
+    List<ServiceReview> getReviewsForProvider(Long providerId);
+
+    List<ServiceReview> getReviewsForUser(Long userId);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/impl/AppointmentServiceImpl.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/impl/AppointmentServiceImpl.java
@@ -1,0 +1,130 @@
+package com.example.housekeeping.service.impl;
+
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.ServiceAppointment;
+import com.example.housekeeping.domain.entity.ServiceProvider;
+import com.example.housekeeping.domain.entity.UserAccount;
+import com.example.housekeeping.domain.enums.AppointmentStatus;
+import com.example.housekeeping.dto.AppointmentAssignmentRequest;
+import com.example.housekeeping.dto.AppointmentCreateRequest;
+import com.example.housekeeping.dto.AppointmentStatusUpdateRequest;
+import com.example.housekeeping.repository.HousekeepingServiceRepository;
+import com.example.housekeeping.repository.ServiceAppointmentRepository;
+import com.example.housekeeping.repository.ServiceProviderRepository;
+import com.example.housekeeping.repository.UserAccountRepository;
+import com.example.housekeeping.service.AppointmentService;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AppointmentServiceImpl implements AppointmentService {
+
+    private final ServiceAppointmentRepository serviceAppointmentRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final HousekeepingServiceRepository housekeepingServiceRepository;
+    private final ServiceProviderRepository serviceProviderRepository;
+
+    @Override
+    public ServiceAppointment createAppointment(Long userId, AppointmentCreateRequest request) {
+        UserAccount user = userAccountRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "用户不存在"));
+        HousekeepingService service = housekeepingServiceRepository.findById(request.serviceId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "服务不存在"));
+        ServiceAppointment appointment = new ServiceAppointment();
+        appointment.setUser(user);
+        appointment.setService(service);
+        appointment.setStatus(AppointmentStatus.PENDING_REVIEW);
+        appointment.setScheduledAt(request.scheduledAt());
+        appointment.setAddress(request.address());
+        appointment.setContactName(request.contactName());
+        appointment.setContactPhone(request.contactPhone());
+        appointment.setUserNotes(request.userNotes());
+        appointment.setPrice(request.price() != null ? request.price() : service.getPrice());
+        return serviceAppointmentRepository.save(appointment);
+    }
+
+    @Override
+    public ServiceAppointment getAppointment(Long id) {
+        return serviceAppointmentRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "预约不存在"));
+    }
+
+    @Override
+    public List<ServiceAppointment> getAppointmentsForUser(Long userId) {
+        return serviceAppointmentRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    @Override
+    public List<ServiceAppointment> getAppointmentsForProvider(Long providerId) {
+        return serviceAppointmentRepository.findByProviderIdOrderByCreatedAtDesc(providerId);
+    }
+
+    @Override
+    public List<ServiceAppointment> getAllAppointments() {
+        return serviceAppointmentRepository.findAll();
+    }
+
+    @Override
+    public ServiceAppointment assignProvider(Long appointmentId, AppointmentAssignmentRequest request, String adminName) {
+        ServiceAppointment appointment = getAppointment(appointmentId);
+        if (appointment.getStatus() == AppointmentStatus.CANCELLED || appointment.getStatus() == AppointmentStatus.COMPLETED) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "已完成或已取消的订单不能分配");
+        }
+        ServiceProvider provider = serviceProviderRepository.findById(request.providerId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "服务者不存在"));
+        appointment.setProvider(provider);
+        appointment.setStatus(AppointmentStatus.ASSIGNED);
+        appointment.setAdminNotes(request.adminNotes());
+        appointment.setAuditBy(adminName);
+        appointment.setAuditAt(LocalDateTime.now());
+        return appointment;
+    }
+
+    @Override
+    public ServiceAppointment updateStatus(Long appointmentId, AppointmentStatusUpdateRequest request, String actor) {
+        ServiceAppointment appointment = getAppointment(appointmentId);
+        AppointmentStatus newStatus = request.status();
+        switch (newStatus) {
+            case APPROVED, REJECTED -> {
+                appointment.setStatus(newStatus);
+                appointment.setAuditBy(actor);
+                appointment.setAuditRemark(request.remark());
+                appointment.setAuditAt(LocalDateTime.now());
+            }
+            case CANCELLED -> {
+                if (appointment.getStatus() == AppointmentStatus.COMPLETED) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "订单已完成，无法取消");
+                }
+                appointment.setStatus(AppointmentStatus.CANCELLED);
+                appointment.setAuditRemark(request.remark());
+            }
+            case IN_SERVICE -> {
+                if (appointment.getStatus() != AppointmentStatus.ASSIGNED && appointment.getStatus() != AppointmentStatus.APPROVED) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "订单尚未分配或审核通过");
+                }
+                appointment.setStatus(AppointmentStatus.IN_SERVICE);
+                appointment.setActualStartAt(LocalDateTime.now());
+            }
+            case COMPLETED -> {
+                if (appointment.getStatus() != AppointmentStatus.IN_SERVICE && appointment.getStatus() != AppointmentStatus.ASSIGNED) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "订单未处于服务中状态");
+                }
+                appointment.setStatus(AppointmentStatus.COMPLETED);
+                appointment.setActualEndAt(LocalDateTime.now());
+                if (appointment.getProvider() != null) {
+                    ServiceProvider provider = appointment.getProvider();
+                    provider.setCompletedOrders(provider.getCompletedOrders() + 1);
+                }
+            }
+            case ASSIGNED, PENDING_REVIEW -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "请通过专用接口更新预约分配或新建预约");
+        }
+        return appointment;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/impl/AuthServiceImpl.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/impl/AuthServiceImpl.java
@@ -1,0 +1,187 @@
+package com.example.housekeeping.service.impl;
+
+import com.example.housekeeping.domain.entity.Admin;
+import com.example.housekeeping.domain.entity.ServiceProvider;
+import com.example.housekeeping.domain.entity.UserAccount;
+import com.example.housekeeping.domain.enums.RoleType;
+import com.example.housekeeping.dto.AuthRequest;
+import com.example.housekeeping.dto.AuthResponse;
+import com.example.housekeeping.dto.RegisterRequest;
+import com.example.housekeeping.dto.UpdatePasswordRequest;
+import com.example.housekeeping.dto.UpdateProfileRequest;
+import com.example.housekeeping.repository.AdminRepository;
+import com.example.housekeeping.repository.ServiceProviderRepository;
+import com.example.housekeeping.repository.UserAccountRepository;
+import com.example.housekeeping.service.AuthService;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+    private final AdminRepository adminRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final ServiceProviderRepository serviceProviderRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public AuthResponse login(AuthRequest request) {
+        return switch (request.role()) {
+            case ADMIN -> adminRepository.findByUsername(request.username())
+                    .filter(admin -> passwordEncoder.matches(request.password(), admin.getPassword()))
+                    .map(admin -> {
+                        admin.setLastLoginAt(LocalDateTime.now());
+                        return buildResponse(admin.getId(), RoleType.ADMIN, admin.getUsername(), admin.getFullName());
+                    })
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "管理员账号或密码不正确"));
+            case USER -> userAccountRepository.findByUsername(request.username())
+                    .filter(user -> passwordEncoder.matches(request.password(), user.getPassword()))
+                    .map(user -> {
+                        if (!user.isEnabled()) {
+                            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "账号已被禁用");
+                        }
+                        user.setLastLoginAt(LocalDateTime.now());
+                        return buildResponse(user.getId(), RoleType.USER, user.getUsername(), user.getFullName());
+                    })
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "用户账号或密码不正确"));
+            case PROVIDER -> serviceProviderRepository.findByUsername(request.username())
+                    .filter(provider -> passwordEncoder.matches(request.password(), provider.getPassword()))
+                    .map(provider -> {
+                        if (!provider.isEnabled()) {
+                            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "账号已被禁用");
+                        }
+                        provider.setLastLoginAt(LocalDateTime.now());
+                        return buildResponse(provider.getId(), RoleType.PROVIDER, provider.getUsername(), provider.getFullName());
+                    })
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "服务者账号或密码不正确"));
+        };
+    }
+
+    @Override
+    public AuthResponse register(RegisterRequest request) {
+        boolean usernameExists = adminRepository.findByUsername(request.username()).isPresent()
+                || userAccountRepository.findByUsername(request.username()).isPresent()
+                || serviceProviderRepository.findByUsername(request.username()).isPresent();
+        if (usernameExists) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "账号已存在");
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.password());
+        LocalDateTime now = LocalDateTime.now();
+        return switch (request.role()) {
+            case ADMIN -> {
+                Admin admin = new Admin();
+                admin.setUsername(request.username());
+                admin.setPassword(encodedPassword);
+                admin.setFullName(Optional.ofNullable(request.fullName()).orElse("管理员"));
+                admin.setEmail(request.email());
+                admin.setPhone(request.phone());
+                admin.setLastLoginAt(now);
+                Admin saved = adminRepository.save(admin);
+                yield buildResponse(saved.getId(), RoleType.ADMIN, saved.getUsername(), saved.getFullName());
+            }
+            case USER -> {
+                UserAccount user = new UserAccount();
+                user.setUsername(request.username());
+                user.setPassword(encodedPassword);
+                user.setFullName(request.fullName());
+                user.setEmail(request.email());
+                user.setPhone(request.phone());
+                user.setAddress(request.address());
+                user.setLastLoginAt(now);
+                UserAccount saved = userAccountRepository.save(user);
+                yield buildResponse(saved.getId(), RoleType.USER, saved.getUsername(), saved.getFullName());
+            }
+            case PROVIDER -> {
+                ServiceProvider provider = new ServiceProvider();
+                provider.setUsername(request.username());
+                provider.setPassword(encodedPassword);
+                provider.setFullName(request.fullName());
+                provider.setEmail(request.email());
+                provider.setPhone(request.phone());
+                provider.setServiceArea(request.address());
+                provider.setLastLoginAt(now);
+                ServiceProvider saved = serviceProviderRepository.save(provider);
+                yield buildResponse(saved.getId(), RoleType.PROVIDER, saved.getUsername(), saved.getFullName());
+            }
+        };
+    }
+
+    @Override
+    public void updatePassword(RoleType role, Long id, UpdatePasswordRequest request) {
+        switch (role) {
+            case ADMIN -> adminRepository.findById(id).ifPresentOrElse(admin -> {
+                ensurePasswordMatches(request.oldPassword(), admin.getPassword());
+                admin.setPassword(passwordEncoder.encode(request.newPassword()));
+            }, () -> { throw new ResponseStatusException(HttpStatus.NOT_FOUND, "管理员不存在"); });
+            case USER -> userAccountRepository.findById(id).ifPresentOrElse(user -> {
+                ensurePasswordMatches(request.oldPassword(), user.getPassword());
+                user.setPassword(passwordEncoder.encode(request.newPassword()));
+            }, () -> { throw new ResponseStatusException(HttpStatus.NOT_FOUND, "用户不存在"); });
+            case PROVIDER -> serviceProviderRepository.findById(id).ifPresentOrElse(provider -> {
+                ensurePasswordMatches(request.oldPassword(), provider.getPassword());
+                provider.setPassword(passwordEncoder.encode(request.newPassword()));
+            }, () -> { throw new ResponseStatusException(HttpStatus.NOT_FOUND, "服务者不存在"); });
+            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "不支持的角色类型");
+        }
+    }
+
+    @Override
+    public void updateProfile(RoleType role, Long id, UpdateProfileRequest request) {
+        switch (role) {
+            case ADMIN -> adminRepository.findById(id).ifPresentOrElse(admin -> {
+                applyCommonProfile(admin, request);
+            }, () -> { throw new ResponseStatusException(HttpStatus.NOT_FOUND, "管理员不存在"); });
+            case USER -> userAccountRepository.findById(id).ifPresentOrElse(user -> {
+                applyCommonProfile(user, request);
+                user.setAddress(request.address());
+            }, () -> { throw new ResponseStatusException(HttpStatus.NOT_FOUND, "用户不存在"); });
+            case PROVIDER -> serviceProviderRepository.findById(id).ifPresentOrElse(provider -> {
+                applyCommonProfile(provider, request);
+                provider.setBiography(request.biography());
+                provider.setServiceArea(request.serviceArea());
+                provider.setSkills(request.skills());
+            }, () -> { throw new ResponseStatusException(HttpStatus.NOT_FOUND, "服务者不存在"); });
+            default -> throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "不支持的角色类型");
+        }
+    }
+
+    private void ensurePasswordMatches(String rawPassword, String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "原密码不正确");
+        }
+    }
+
+    private void applyCommonProfile(Admin admin, UpdateProfileRequest request) {
+        admin.setFullName(request.fullName());
+        admin.setPhone(request.phone());
+        admin.setEmail(request.email());
+        admin.setAvatarUrl(request.avatarUrl());
+    }
+
+    private void applyCommonProfile(UserAccount user, UpdateProfileRequest request) {
+        user.setFullName(request.fullName());
+        user.setPhone(request.phone());
+        user.setEmail(request.email());
+        user.setAvatarUrl(request.avatarUrl());
+    }
+
+    private void applyCommonProfile(ServiceProvider provider, UpdateProfileRequest request) {
+        provider.setFullName(request.fullName());
+        provider.setPhone(request.phone());
+        provider.setEmail(request.email());
+        provider.setAvatarUrl(request.avatarUrl());
+    }
+
+    private AuthResponse buildResponse(Long id, RoleType role, String username, String displayName) {
+        return new AuthResponse(id, role, username, displayName, LocalDateTime.now());
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/impl/CertificationServiceImpl.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/impl/CertificationServiceImpl.java
@@ -1,0 +1,70 @@
+package com.example.housekeeping.service.impl;
+
+import com.example.housekeeping.domain.entity.ProviderCertification;
+import com.example.housekeeping.domain.entity.ServiceProvider;
+import com.example.housekeeping.domain.enums.CertificationStatus;
+import com.example.housekeeping.dto.CertificationReviewRequest;
+import com.example.housekeeping.dto.CertificationSubmissionRequest;
+import com.example.housekeeping.repository.ProviderCertificationRepository;
+import com.example.housekeeping.repository.ServiceProviderRepository;
+import com.example.housekeeping.service.CertificationService;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CertificationServiceImpl implements CertificationService {
+
+    private final ProviderCertificationRepository providerCertificationRepository;
+    private final ServiceProviderRepository serviceProviderRepository;
+
+    @Override
+    public ProviderCertification submitCertification(Long providerId, CertificationSubmissionRequest request) {
+        ServiceProvider provider = serviceProviderRepository.findById(providerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "服务者不存在"));
+        ProviderCertification certification = new ProviderCertification();
+        certification.setProvider(provider);
+        certification.setDocuments(request.documents());
+        certification.setExperienceYears(request.experienceYears());
+        certification.setSpeciality(request.speciality());
+        certification.setStatus(CertificationStatus.PENDING);
+        certification.setSubmittedAt(LocalDateTime.now());
+        provider.setCertified(false);
+        return providerCertificationRepository.save(certification);
+    }
+
+    @Override
+    public ProviderCertification reviewCertification(Long certificationId, CertificationReviewRequest request) {
+        ProviderCertification certification = providerCertificationRepository.findById(certificationId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "认证记录不存在"));
+        certification.setStatus(request.status());
+        certification.setAuditRemark(request.remark());
+        certification.setReviewedBy(request.reviewedBy());
+        certification.setReviewedAt(LocalDateTime.now());
+        if (request.status() == CertificationStatus.APPROVED) {
+            ServiceProvider provider = certification.getProvider();
+            provider.setCertified(true);
+        }
+        return certification;
+    }
+
+    @Override
+    public List<ProviderCertification> listCertifications(CertificationStatus status) {
+        if (status == null) {
+            return providerCertificationRepository.findAll();
+        }
+        return providerCertificationRepository.findByStatus(status);
+    }
+
+    @Override
+    public ProviderCertification latestCertification(Long providerId) {
+        return providerCertificationRepository.findTopByProviderIdOrderByCreatedAtDesc(providerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "暂无认证记录"));
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/impl/DashboardServiceImpl.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/impl/DashboardServiceImpl.java
@@ -1,0 +1,124 @@
+package com.example.housekeeping.service.impl;
+
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.RechargeRecord;
+import com.example.housekeeping.domain.entity.ServiceAppointment;
+import com.example.housekeeping.domain.entity.WithdrawalRecord;
+import com.example.housekeeping.domain.enums.AppointmentStatus;
+import com.example.housekeeping.domain.enums.CertificationStatus;
+import com.example.housekeeping.dto.DashboardStatsResponse;
+import com.example.housekeeping.repository.HousekeepingServiceRepository;
+import com.example.housekeeping.repository.ProviderCertificationRepository;
+import com.example.housekeeping.repository.RechargeRecordRepository;
+import com.example.housekeeping.repository.ServiceAppointmentRepository;
+import com.example.housekeeping.repository.ServiceProviderRepository;
+import com.example.housekeeping.repository.UserAccountRepository;
+import com.example.housekeeping.repository.WithdrawalRecordRepository;
+import com.example.housekeeping.service.DashboardService;
+import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DashboardServiceImpl implements DashboardService {
+
+    private final UserAccountRepository userAccountRepository;
+    private final ServiceProviderRepository serviceProviderRepository;
+    private final HousekeepingServiceRepository housekeepingServiceRepository;
+    private final ServiceAppointmentRepository serviceAppointmentRepository;
+    private final RechargeRecordRepository rechargeRecordRepository;
+    private final WithdrawalRecordRepository withdrawalRecordRepository;
+    private final ProviderCertificationRepository providerCertificationRepository;
+
+    @Override
+    public DashboardStatsResponse loadDashboardStats() {
+        long totalUsers = userAccountRepository.count();
+        long totalProviders = serviceProviderRepository.count();
+        long totalServices = housekeepingServiceRepository.count();
+        long totalAppointments = serviceAppointmentRepository.count();
+        long pendingAppointments = serviceAppointmentRepository.countByStatus(AppointmentStatus.PENDING_REVIEW);
+        long pendingCertifications = providerCertificationRepository.countByStatus(CertificationStatus.PENDING);
+        long totalRecharges = rechargeRecordRepository.count();
+        long totalWithdrawals = withdrawalRecordRepository.count();
+
+        BigDecimal rechargeSum = rechargeRecordRepository.findAll().stream()
+                .map(recharge -> recharge.getAmount() != null ? recharge.getAmount() : BigDecimal.ZERO)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal withdrawalSum = withdrawalRecordRepository.findAll().stream()
+                .map(withdrawal -> withdrawal.getAmount() != null ? withdrawal.getAmount() : BigDecimal.ZERO)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        List<DashboardStatsResponse.TrendPoint> rechargeTrend = buildRechargeTrend();
+        List<DashboardStatsResponse.TrendPoint> appointmentTrend = buildAppointmentTrend();
+        List<DashboardStatsResponse.CategoryCount> categoryDistribution = buildCategoryDistribution();
+
+        return new DashboardStatsResponse(
+                totalUsers,
+                totalProviders,
+                totalServices,
+                totalAppointments,
+                pendingAppointments,
+                pendingCertifications,
+                totalRecharges,
+                totalWithdrawals,
+                rechargeSum.setScale(2, RoundingMode.HALF_UP),
+                withdrawalSum.setScale(2, RoundingMode.HALF_UP),
+                rechargeTrend,
+                appointmentTrend,
+                categoryDistribution
+        );
+    }
+
+    private List<DashboardStatsResponse.TrendPoint> buildRechargeTrend() {
+        List<RechargeRecord> records = rechargeRecordRepository.findAll();
+        LocalDate today = LocalDate.now();
+        List<DashboardStatsResponse.TrendPoint> trendPoints = new ArrayList<>();
+        for (int i = 6; i >= 0; i--) {
+            LocalDate day = today.minusDays(i);
+            BigDecimal sum = records.stream()
+                    .filter(record -> record.getCreatedAt() != null && record.getCreatedAt().toLocalDate().equals(day))
+                    .map(record -> record.getAmount() != null ? record.getAmount() : BigDecimal.ZERO)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            trendPoints.add(new DashboardStatsResponse.TrendPoint(day.toString(), sum.setScale(2, RoundingMode.HALF_UP)));
+        }
+        return trendPoints;
+    }
+
+    private List<DashboardStatsResponse.TrendPoint> buildAppointmentTrend() {
+        List<ServiceAppointment> appointments = serviceAppointmentRepository.findAll();
+        LocalDate today = LocalDate.now();
+        List<DashboardStatsResponse.TrendPoint> trendPoints = new ArrayList<>();
+        for (int i = 6; i >= 0; i--) {
+            LocalDate day = today.minusDays(i);
+            long count = appointments.stream()
+                    .filter(appointment -> appointment.getCreatedAt() != null
+                            && appointment.getCreatedAt().toLocalDate().equals(day))
+                    .count();
+            trendPoints.add(new DashboardStatsResponse.TrendPoint(day.toString(), count));
+        }
+        return trendPoints;
+    }
+
+    private List<DashboardStatsResponse.CategoryCount> buildCategoryDistribution() {
+        List<HousekeepingService> services = housekeepingServiceRepository.findAll();
+        Map<String, Long> grouped = services.stream()
+                .collect(Collectors.groupingBy(service -> service.getCategory() != null
+                                ? service.getCategory().getName()
+                                : "未分类",
+                        Collectors.counting()));
+        return grouped.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> new DashboardStatsResponse.CategoryCount(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/impl/FavoriteServiceManagerImpl.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/impl/FavoriteServiceManagerImpl.java
@@ -1,0 +1,53 @@
+package com.example.housekeeping.service.impl;
+
+import com.example.housekeeping.domain.entity.FavoriteService;
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.UserAccount;
+import com.example.housekeeping.repository.FavoriteServiceRepository;
+import com.example.housekeeping.repository.HousekeepingServiceRepository;
+import com.example.housekeeping.repository.UserAccountRepository;
+import com.example.housekeeping.service.FavoriteServiceManager;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FavoriteServiceManagerImpl implements FavoriteServiceManager {
+
+    private final FavoriteServiceRepository favoriteServiceRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final HousekeepingServiceRepository housekeepingServiceRepository;
+
+    @Override
+    public FavoriteService addFavorite(Long userId, Long serviceId) {
+        FavoriteService existing = favoriteServiceRepository.findByUserIdAndServiceId(userId, serviceId).orElse(null);
+        if (existing != null) {
+            return existing;
+        }
+        UserAccount user = userAccountRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "用户不存在"));
+        HousekeepingService service = housekeepingServiceRepository.findById(serviceId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "服务不存在"));
+        FavoriteService favorite = new FavoriteService();
+        favorite.setUser(user);
+        favorite.setService(service);
+        return favoriteServiceRepository.save(favorite);
+    }
+
+    @Override
+    public void removeFavorite(Long userId, Long serviceId) {
+        favoriteServiceRepository.findByUserIdAndServiceId(userId, serviceId)
+                .ifPresentOrElse(favoriteServiceRepository::delete,
+                        () -> { throw new ResponseStatusException(HttpStatus.NOT_FOUND, "收藏记录不存在"); });
+    }
+
+    @Override
+    public List<FavoriteService> getFavoritesForUser(Long userId) {
+        return favoriteServiceRepository.findByUserId(userId);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/impl/FinanceServiceImpl.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/impl/FinanceServiceImpl.java
@@ -1,0 +1,105 @@
+package com.example.housekeeping.service.impl;
+
+import com.example.housekeeping.domain.entity.RechargeRecord;
+import com.example.housekeeping.domain.entity.ServiceProvider;
+import com.example.housekeeping.domain.entity.UserAccount;
+import com.example.housekeeping.domain.entity.WithdrawalRecord;
+import com.example.housekeeping.domain.enums.PaymentStatus;
+import com.example.housekeeping.domain.enums.WithdrawalStatus;
+import com.example.housekeeping.dto.RechargeRequest;
+import com.example.housekeeping.dto.WithdrawalProcessRequest;
+import com.example.housekeeping.dto.WithdrawalRequest;
+import com.example.housekeeping.repository.RechargeRecordRepository;
+import com.example.housekeeping.repository.ServiceProviderRepository;
+import com.example.housekeeping.repository.UserAccountRepository;
+import com.example.housekeeping.repository.WithdrawalRecordRepository;
+import com.example.housekeeping.service.FinanceService;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FinanceServiceImpl implements FinanceService {
+
+    private final RechargeRecordRepository rechargeRecordRepository;
+    private final WithdrawalRecordRepository withdrawalRecordRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final ServiceProviderRepository serviceProviderRepository;
+
+    @Override
+    public RechargeRecord createRecharge(Long userId, RechargeRequest request) {
+        UserAccount user = userAccountRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "用户不存在"));
+        RechargeRecord record = new RechargeRecord();
+        record.setUser(user);
+        record.setAmount(request.amount());
+        record.setPaymentMethod(request.paymentMethod());
+        record.setReferenceNo(UUID.randomUUID().toString());
+        record.setStatus(PaymentStatus.SUCCESS);
+        record.setPaidAt(LocalDateTime.now());
+        RechargeRecord saved = rechargeRecordRepository.save(record);
+        user.setBalance(user.getBalance().add(request.amount()));
+        return saved;
+    }
+
+    @Override
+    public List<RechargeRecord> getRechargesForUser(Long userId) {
+        return rechargeRecordRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    @Override
+    public List<RechargeRecord> getAllRecharges() {
+        return rechargeRecordRepository.findAll();
+    }
+
+    @Override
+    public WithdrawalRecord requestWithdrawal(Long providerId, WithdrawalRequest request) {
+        ServiceProvider provider = serviceProviderRepository.findById(providerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "服务者不存在"));
+        if (provider.getBalance().compareTo(request.amount()) < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "余额不足");
+        }
+        WithdrawalRecord record = new WithdrawalRecord();
+        record.setProvider(provider);
+        record.setAmount(request.amount());
+        record.setAccountInfo(request.accountInfo());
+        record.setStatus(WithdrawalStatus.PENDING);
+        record.setRequestedAt(LocalDateTime.now());
+        return withdrawalRecordRepository.save(record);
+    }
+
+    @Override
+    public WithdrawalRecord processWithdrawal(Long withdrawalId, WithdrawalProcessRequest request) {
+        WithdrawalRecord record = withdrawalRecordRepository.findById(withdrawalId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "提现记录不存在"));
+        record.setStatus(request.status());
+        record.setRemark(request.remark());
+        record.setProcessedBy(request.processedBy());
+        record.setProcessedAt(LocalDateTime.now());
+        if (request.status() == WithdrawalStatus.PAID) {
+            ServiceProvider provider = record.getProvider();
+            if (provider.getBalance().compareTo(record.getAmount()) < 0) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "服务者余额不足，无法完成打款");
+            }
+            provider.setBalance(provider.getBalance().subtract(record.getAmount()));
+        }
+        return record;
+    }
+
+    @Override
+    public List<WithdrawalRecord> getWithdrawalsForProvider(Long providerId) {
+        return withdrawalRecordRepository.findByProviderIdOrderByCreatedAtDesc(providerId);
+    }
+
+    @Override
+    public List<WithdrawalRecord> getAllWithdrawals() {
+        return withdrawalRecordRepository.findAll();
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/impl/HousekeepingCatalogServiceImpl.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/impl/HousekeepingCatalogServiceImpl.java
@@ -1,0 +1,118 @@
+package com.example.housekeeping.service.impl;
+
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.ServiceCategory;
+import com.example.housekeeping.dto.HousekeepingServiceRequest;
+import com.example.housekeeping.dto.ServiceCategoryRequest;
+import com.example.housekeeping.repository.HousekeepingServiceRepository;
+import com.example.housekeeping.repository.ServiceCategoryRepository;
+import com.example.housekeeping.service.HousekeepingCatalogService;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HousekeepingCatalogServiceImpl implements HousekeepingCatalogService {
+
+    private final ServiceCategoryRepository serviceCategoryRepository;
+    private final HousekeepingServiceRepository housekeepingServiceRepository;
+
+    @Override
+    public List<ServiceCategory> listCategories() {
+        return serviceCategoryRepository.findAll();
+    }
+
+    @Override
+    public ServiceCategory createCategory(ServiceCategoryRequest request) {
+        ServiceCategory category = new ServiceCategory();
+        category.setName(request.name());
+        category.setDescription(request.description());
+        category.setIconUrl(request.iconUrl());
+        category.setSortOrder(request.sortOrder() != null ? request.sortOrder() : 0);
+        category.setEnabled(request.enabled());
+        return serviceCategoryRepository.save(category);
+    }
+
+    @Override
+    public ServiceCategory updateCategory(Long id, ServiceCategoryRequest request) {
+        ServiceCategory category = serviceCategoryRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "分类不存在"));
+        category.setName(request.name());
+        category.setDescription(request.description());
+        category.setIconUrl(request.iconUrl());
+        category.setSortOrder(request.sortOrder() != null ? request.sortOrder() : category.getSortOrder());
+        category.setEnabled(request.enabled());
+        return category;
+    }
+
+    @Override
+    public void deleteCategory(Long id) {
+        if (!serviceCategoryRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "分类不存在");
+        }
+        serviceCategoryRepository.deleteById(id);
+    }
+
+    @Override
+    public List<HousekeepingService> listServices() {
+        return housekeepingServiceRepository.findAll();
+    }
+
+    @Override
+    public List<HousekeepingService> listServicesByCategory(Long categoryId) {
+        return housekeepingServiceRepository.findByCategoryId(categoryId);
+    }
+
+    @Override
+    public List<HousekeepingService> listFeaturedServices() {
+        return housekeepingServiceRepository.findByFeaturedTrueOrderByOrderCountDesc();
+    }
+
+    @Override
+    public HousekeepingService createService(HousekeepingServiceRequest request) {
+        ServiceCategory category = serviceCategoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "分类不存在"));
+        HousekeepingService service = new HousekeepingService();
+        service.setCategory(category);
+        service.setTitle(request.title());
+        service.setDescription(request.description());
+        service.setPrice(request.price());
+        service.setDurationMinutes(request.durationMinutes());
+        service.setFeatured(request.featured());
+        service.setCoverImageUrl(request.coverImageUrl());
+        service.setTags(request.tags());
+        service.setEnabled(request.enabled());
+        return housekeepingServiceRepository.save(service);
+    }
+
+    @Override
+    public HousekeepingService updateService(Long id, HousekeepingServiceRequest request) {
+        HousekeepingService service = housekeepingServiceRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "服务不存在"));
+        ServiceCategory category = serviceCategoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "分类不存在"));
+        service.setCategory(category);
+        service.setTitle(request.title());
+        service.setDescription(request.description());
+        service.setPrice(request.price());
+        service.setDurationMinutes(request.durationMinutes());
+        service.setFeatured(request.featured());
+        service.setCoverImageUrl(request.coverImageUrl());
+        service.setTags(request.tags());
+        service.setEnabled(request.enabled());
+        return service;
+    }
+
+    @Override
+    public void deleteService(Long id) {
+        if (!housekeepingServiceRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "服务不存在");
+        }
+        housekeepingServiceRepository.deleteById(id);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/impl/ReviewServiceImpl.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/impl/ReviewServiceImpl.java
@@ -1,0 +1,110 @@
+package com.example.housekeeping.service.impl;
+
+import com.example.housekeeping.domain.entity.HousekeepingService;
+import com.example.housekeeping.domain.entity.ServiceAppointment;
+import com.example.housekeeping.domain.entity.ServiceProvider;
+import com.example.housekeeping.domain.entity.ServiceReview;
+import com.example.housekeeping.domain.enums.AppointmentStatus;
+import com.example.housekeeping.dto.ReviewReplyRequest;
+import com.example.housekeeping.dto.ServiceReviewRequest;
+import com.example.housekeeping.repository.ServiceAppointmentRepository;
+import com.example.housekeeping.repository.ServiceReviewRepository;
+import com.example.housekeeping.service.ReviewService;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewServiceImpl implements ReviewService {
+
+    private final ServiceReviewRepository serviceReviewRepository;
+    private final ServiceAppointmentRepository serviceAppointmentRepository;
+
+    @Override
+    public ServiceReview submitReview(Long userId, ServiceReviewRequest request) {
+        ServiceAppointment appointment = serviceAppointmentRepository.findById(request.appointmentId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "预约不存在"));
+        if (appointment.getUser() == null || !appointment.getUser().getId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "无权评价该预约");
+        }
+        if (appointment.getStatus() != AppointmentStatus.COMPLETED) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "服务未完成，无法评价");
+        }
+        serviceReviewRepository.findByAppointmentId(request.appointmentId())
+                .ifPresent(existing -> {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "该预约已评价");
+                });
+        ServiceReview review = new ServiceReview();
+        review.setAppointment(appointment);
+        review.setUser(appointment.getUser());
+        review.setProvider(appointment.getProvider());
+        review.setService(appointment.getService());
+        review.setRating(request.rating());
+        review.setComment(request.comment());
+        ServiceReview saved = serviceReviewRepository.save(review);
+        recalculateServiceRating(appointment.getService());
+        if (appointment.getProvider() != null) {
+            recalculateProviderRating(appointment.getProvider());
+        }
+        return saved;
+    }
+
+    @Override
+    public ServiceReview replyReview(Long reviewId, ReviewReplyRequest request, Long providerId) {
+        ServiceReview review = serviceReviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "评价不存在"));
+        if (review.getProvider() == null || !review.getProvider().getId().equals(providerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "无权回复该评价");
+        }
+        review.setReply(request.reply());
+        review.setRepliedAt(LocalDateTime.now());
+        return review;
+    }
+
+    @Override
+    public List<ServiceReview> getReviewsForService(Long serviceId) {
+        return serviceReviewRepository.findByServiceId(serviceId);
+    }
+
+    @Override
+    public List<ServiceReview> getReviewsForProvider(Long providerId) {
+        return serviceReviewRepository.findByProviderId(providerId);
+    }
+
+    @Override
+    public List<ServiceReview> getReviewsForUser(Long userId) {
+        return serviceReviewRepository.findByUserId(userId);
+    }
+
+    private void recalculateServiceRating(HousekeepingService service) {
+        if (service == null) {
+            return;
+        }
+        List<ServiceReview> reviews = serviceReviewRepository.findByServiceId(service.getId());
+        if (reviews.isEmpty()) {
+            service.setRating(null);
+            return;
+        }
+        double average = reviews.stream().mapToInt(ServiceReview::getRating).average().orElse(0.0);
+        service.setRating(Math.round(average * 10.0) / 10.0);
+    }
+
+    private void recalculateProviderRating(ServiceProvider provider) {
+        if (provider == null) {
+            return;
+        }
+        List<ServiceReview> reviews = serviceReviewRepository.findByProviderId(provider.getId());
+        if (reviews.isEmpty()) {
+            provider.setRating(null);
+            return;
+        }
+        double average = reviews.stream().mapToInt(ServiceReview::getRating).average().orElse(0.0);
+        provider.setRating(Math.round(average * 10.0) / 10.0);
+    }
+}

--- a/housekeeping/src/main/resources/application.properties
+++ b/housekeeping/src/main/resources/application.properties
@@ -1,1 +1,17 @@
 spring.application.name=housekeeping
+
+# DataSource configuration - default to in-memory H2 for local development.
+spring.datasource.url=jdbc:h2:mem:housekeeping;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false


### PR DESCRIPTION
## Summary
- add a full set of JPA entities, repositories, DTOs, and enums to model administrators, users, providers, services, appointments, finances, content, and certifications
- implement service and controller layers covering authentication, catalog browsing, appointment workflows, wallet operations, dashboard statistics, content management, and reviews
- configure application infrastructure including CORS, password encoding, H2 defaults, global error handling, and seeded demo data

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_b_68e359912df4832caf1a093103e15904