### PR TITLE
Implement database-backed login panel

### DIFF
--- a/housekeeping-web/src/router/index.ts
+++ b/housekeeping-web/src/router/index.ts
@@ -19,81 +19,42 @@ const router = createRouter({
       component: () => import('../views/RegisterView.vue'),
     },
     {
-      path: '/user-home',
-      name: 'user-home',
-      component: () => import('../views/UserHomeView.vue'),
-      meta: { requiresAuth: true }
-    },
-    {
-      path: '/provider-home',
-      name: 'provider-home',
-      component: () => import('../views/ProviderHomeView.vue'),
-      meta: { requiresAuth: true }
-    },
-    {
-      path: '/admin-home',
-      name: 'admin-home',
-      component: () => import('../views/AdminHomeView.vue'),
+      path: '/panel',
+      name: 'panel',
+      component: () => import('../views/PanelView.vue'),
       meta: { requiresAuth: true }
     },
   ],
 })
 
-// 路由守卫
 router.beforeEach((to, from, next) => {
-  // 检查路由是否需要认证
   if (to.meta.requiresAuth) {
-    // 检查用户是否已登录
     const userInfo = localStorage.getItem('userInfo')
-    
-    if (userInfo) {
-      try {
-        const user = JSON.parse(userInfo)
-        // 检查登录时间是否超过24小时
-        const loginTime = new Date(user.loginTime)
-        const now = new Date()
-        const hoursDiff = (now.getTime() - loginTime.getTime()) / (1000 * 60 * 60)
-        
-        if (hoursDiff > 24) {
-          // 登录过期，清除用户信息并跳转到登录页
-          localStorage.removeItem('userInfo')
-          next('/login')
-        } else {
-          // 用户已登录且未过期，检查角色权限
-          if (user.role === 'admin') {
-            // 管理员角色只能访问管理员页面
-            if (to.name !== 'admin-home') {
-              next('/admin-home')
-            } else {
-              next()
-            }
-          } else if (user.role === 'provider') {
-            // 家政人员角色只能访问家政人员页面
-            if (to.name !== 'provider-home') {
-              next('/provider-home')
-            } else {
-              next()
-            }
-          } else {
-            // 用户角色只能访问用户页面
-            if (to.name !== 'user-home') {
-              next('/user-home')
-            } else {
-              next()
-            }
-          }
-        }
-      } catch (error) {
-        // 用户信息格式错误，清除并跳转到登录页
+
+    if (!userInfo) {
+      next('/login')
+      return
+    }
+
+    try {
+      const user = JSON.parse(userInfo)
+      const loginTime = new Date(user.loginTime)
+      const now = new Date()
+      const hoursDiff = (now.getTime() - loginTime.getTime()) / (1000 * 60 * 60)
+
+      if (hoursDiff > 24) {
         localStorage.removeItem('userInfo')
         next('/login')
+      } else {
+        next()
       }
-    } else {
-      // 用户未登录，跳转到登录页
+    } catch (error) {
+      localStorage.removeItem('userInfo')
       next('/login')
     }
+  } else if ((to.path === '/' || to.path === '/login') && localStorage.getItem('userInfo')) {
+    next('/panel')
   } else {
-    // 不需要认证的路由，直接访问
     next()
   }
 })

--- a/housekeeping-web/src/views/PanelView.vue
+++ b/housekeeping-web/src/views/PanelView.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="panel-container">
+    <div class="panel-card" v-if="userInfo">
+      <h1 class="panel-title">欢迎您{{ userInfo.usertype }}:{{ userInfo.username }}</h1>
+      <p v-if="userInfo.usermoney !== undefined && userInfo.usermoney !== null" class="panel-balance">
+        账户余额：{{ formatMoney(userInfo.usermoney) }}
+      </p>
+    </div>
+    <div v-else class="panel-card">
+      <h1 class="panel-title">欢迎使用家政服务平台</h1>
+      <p class="panel-balance">请重新登录。</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const userInfo = computed(() => {
+  const raw = localStorage.getItem('userInfo')
+  if (!raw) {
+    router.replace('/login')
+    return null
+  }
+
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    localStorage.removeItem('userInfo')
+    router.replace('/login')
+    return null
+  }
+})
+
+const formatMoney = (value: number) => {
+  return Number(value).toFixed(2)
+}
+</script>
+
+<style scoped>
+.panel-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #f5f5f5, #e0e0e0);
+  padding: 20px;
+}
+
+.panel-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 40px 60px;
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.panel-title {
+  font-size: 28px;
+  color: #333333;
+  margin-bottom: 16px;
+}
+
+.panel-balance {
+  font-size: 18px;
+  color: #555555;
+}
+</style>

--- a/housekeeping/pom.xml
+++ b/housekeeping/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.mysql</groupId>
@@ -52,6 +56,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/housekeeping/src/main/java/com/example/housekeeping/config/WebConfig.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.example.housekeeping.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins("http://localhost:5173", "http://127.0.0.1:5173")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(false)
+                        .maxAge(3600);
+            }
+        };
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/controller/AuthController.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.example.housekeeping.controller;
+
+import com.example.housekeeping.dto.LoginRequest;
+import com.example.housekeeping.dto.LoginResponse;
+import com.example.housekeeping.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@CrossOrigin(origins = {"http://localhost:5173", "http://127.0.0.1:5173"})
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/LoginRequest.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/LoginRequest.java
@@ -1,0 +1,39 @@
+package com.example.housekeeping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @NotBlank(message = "用户名不能为空")
+    private String username;
+
+    @NotBlank(message = "密码不能为空")
+    private String password;
+
+    @NotBlank(message = "用户类型不能为空")
+    private String usertype;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getUsertype() {
+        return usertype;
+    }
+
+    public void setUsertype(String usertype) {
+        this.usertype = usertype;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/dto/LoginResponse.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/dto/LoginResponse.java
@@ -1,0 +1,28 @@
+package com.example.housekeeping.dto;
+
+import java.math.BigDecimal;
+
+public class LoginResponse {
+
+    private final String username;
+    private final String usertype;
+    private final BigDecimal usermoney;
+
+    public LoginResponse(String username, String usertype, BigDecimal usermoney) {
+        this.username = username;
+        this.usertype = usertype;
+        this.usermoney = usermoney;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getUsertype() {
+        return usertype;
+    }
+
+    public BigDecimal getUsermoney() {
+        return usermoney;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/entity/UserForHousekeeper.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/entity/UserForHousekeeper.java
@@ -1,0 +1,58 @@
+package com.example.housekeeping.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "user_for_housekeeper")
+public class UserForHousekeeper {
+
+    @Id
+    @Column(name = "username", nullable = false, length = 64)
+    private String username;
+
+    @Column(name = "password", nullable = false, length = 64)
+    private String password;
+
+    @Column(name = "usertype", nullable = false, length = 32)
+    private String usertype;
+
+    @Column(name = "usermoney")
+    private BigDecimal usermoney;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getUsertype() {
+        return usertype;
+    }
+
+    public void setUsertype(String usertype) {
+        this.usertype = usertype;
+    }
+
+    public BigDecimal getUsermoney() {
+        return usermoney;
+    }
+
+    public void setUsermoney(BigDecimal usermoney) {
+        this.usermoney = usermoney;
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/exception/GlobalExceptionHandler.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.example.housekeeping.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+        if (fieldError != null) {
+            body.put("message", fieldError.getDefaultMessage());
+        } else {
+            body.put("message", "请求参数不合法");
+        }
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidCredentials(InvalidCredentialsException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", HttpStatus.UNAUTHORIZED.value());
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+        body.put("message", "服务器内部错误");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/exception/InvalidCredentialsException.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/exception/InvalidCredentialsException.java
@@ -1,0 +1,12 @@
+package com.example.housekeeping.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class InvalidCredentialsException extends RuntimeException {
+
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/UserForHousekeeperRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/UserForHousekeeperRepository.java
@@ -1,0 +1,10 @@
+package com.example.housekeeping.repository;
+
+import com.example.housekeeping.entity.UserForHousekeeper;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserForHousekeeperRepository extends JpaRepository<UserForHousekeeper, String> {
+    Optional<UserForHousekeeper> findByUsername(String username);
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/service/AuthService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/AuthService.java
@@ -1,0 +1,36 @@
+package com.example.housekeeping.service;
+
+import com.example.housekeeping.dto.LoginRequest;
+import com.example.housekeeping.dto.LoginResponse;
+import com.example.housekeeping.entity.UserForHousekeeper;
+import com.example.housekeeping.exception.InvalidCredentialsException;
+import com.example.housekeeping.repository.UserForHousekeeperRepository;
+import com.example.housekeeping.util.PasswordTransformer;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+
+    private final UserForHousekeeperRepository repository;
+
+    public AuthService(UserForHousekeeperRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest request) {
+        UserForHousekeeper user = repository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new InvalidCredentialsException("账号或密码错误"));
+
+        if (!user.getUsertype().equalsIgnoreCase(request.getUsertype())) {
+            throw new InvalidCredentialsException("账号或角色不匹配");
+        }
+
+        if (!PasswordTransformer.matches(request.getPassword(), user.getPassword())) {
+            throw new InvalidCredentialsException("账号或密码错误");
+        }
+
+        return new LoginResponse(user.getUsername(), user.getUsertype(), user.getUsermoney());
+    }
+}

--- a/housekeeping/src/main/java/com/example/housekeeping/util/PasswordTransformer.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/util/PasswordTransformer.java
@@ -1,0 +1,36 @@
+package com.example.housekeeping.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public final class PasswordTransformer {
+
+    private PasswordTransformer() {
+    }
+
+    public static String encode(String rawPassword) {
+        String base64 = Base64.getEncoder().encodeToString(rawPassword.getBytes(StandardCharsets.UTF_8));
+        String reversed = new StringBuilder(base64).reverse().toString();
+        try {
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            byte[] digest = md5.digest(reversed.getBytes(StandardCharsets.UTF_8));
+            return toHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 algorithm not available", e);
+        }
+    }
+
+    public static boolean matches(String rawPassword, String encodedPassword) {
+        return encode(rawPassword).equalsIgnoreCase(encodedPassword);
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/housekeeping/src/main/resources/application.properties
+++ b/housekeeping/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=housekeeping
+spring.datasource.url=jdbc:mysql://localhost:3306/housekeeping?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai&useSSL=false
+spring.datasource.username=root
+spring.datasource.password=your_password
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=false
+spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/housekeeping/src/test/resources/application.properties
+++ b/housekeeping/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:housekeeping-test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect

--- a/sql/user_for_housekeeper.sql
+++ b/sql/user_for_housekeeper.sql
@@ -1,0 +1,18 @@
+CREATE DATABASE IF NOT EXISTS housekeeping CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE housekeeping;
+
+CREATE TABLE IF NOT EXISTS user_for_housekeeper (
+    username VARCHAR(64) NOT NULL PRIMARY KEY COMMENT '用户名',
+    password VARCHAR(64) NOT NULL COMMENT '密码（Base64 -> 倒置 -> MD5）',
+    usertype VARCHAR(32) NOT NULL COMMENT '用户类型（admin/user/provider）',
+    usermoney DECIMAL(10,2) DEFAULT 0 COMMENT '账户余额'
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '家政平台用户表';
+
+INSERT INTO user_for_housekeeper (username, password, usertype, usermoney) VALUES
+    ('admin', 'f5c373fcba202c9bdaf15caf70780235', 'admin', 1000.00),
+    ('provider', 'ffd5c43bf98d28dcf651f07a637abb05', 'provider', 500.00),
+    ('user', '969af486f1215c68555b405f84c586cc', 'user', 200.00)
+ON DUPLICATE KEY UPDATE
+    password = VALUES(password),
+    usertype = VALUES(usertype),
+    usermoney = VALUES(usermoney);


### PR DESCRIPTION
## Summary
- add MySQL-backed authentication API with Base64-reverse-MD5 password handling and supporting SQL seed script
- configure Vue login flow to consume the new endpoint, centralize routing on `/panel`, and display the authenticated user details
- extend backend configuration for database access, test isolation, and cross-origin support

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_b_68e6405e489c832cae7083fd5a863003