### PR TITLE
Handle admin account cleanup and show tourist service images

### DIFF
--- a/housekeeping-web/src/views/AdminDashboardView.vue
+++ b/housekeeping-web/src/views/AdminDashboardView.vue
@@ -15,7 +15,7 @@
     <section class="stats-grid" aria-label="平台概览">
       <article class="stat-card accent">
         <p class="stat-label">平台注册用户</p>
-        <p class="stat-value">{{ adminStats.totalUsers }}</p>
+        <p class="stat-value">{{ adminStats.totalAccounts }}</p>
         <p class="stat-helper">普通用户 + 家政公司 + 管理员</p>
       </article>
       <article class="stat-card primary">
@@ -26,7 +26,7 @@
       <article class="stat-card glass">
         <p class="stat-label">累计充值</p>
         <p class="stat-value">¥{{ adminStats.totalRecharge.toFixed(2) }}</p>
-        <p class="stat-helper">提现 {{ adminStats.totalWithdraw.toFixed(2) }}</p>
+        <p class="stat-helper">家政公司 {{ adminStats.totalCompanies }}</p>
       </article>
       <article class="stat-card warning">
         <p class="stat-label">待审退款</p>
@@ -150,7 +150,7 @@
               <ul class="stat-lines">
                 <li><span>管理员数量</span><strong>{{ adminStats.totalAdmins }}</strong></li>
                 <li><span>普通用户</span><strong>{{ normalUserCount }}</strong></li>
-                <li><span>累计提现</span><strong>¥{{ adminStats.totalWithdraw.toFixed(2) }}</strong></li>
+                <li><span>家政公司</span><strong>{{ adminStats.totalCompanies }}</strong></li>
               </ul>
             </article>
           </div>
@@ -1632,19 +1632,21 @@ const hasAnnouncementFilter = computed(() => announcementSearch.value.trim().len
 
 const adminStats = computed(() => {
   const base = overview.value
+  const totalUsers = Number(base?.totalUsers ?? 0)
+  const totalCompanies = Number(base?.totalCompanies ?? 0)
+  const totalAdmins = Number(base?.totalAdmins ?? 0)
   return {
-    totalUsers: base?.totalUsers ?? 0,
-    totalCompanies: base?.totalCompanies ?? 0,
-    totalAdmins: base?.totalAdmins ?? 0,
+    totalUsers,
+    totalCompanies,
+    totalAdmins,
+    totalAccounts: totalUsers + totalCompanies + totalAdmins,
     totalRecharge: Number(base?.totalRecharge ?? 0),
     totalWithdraw: Number(base?.totalWithdraw ?? 0),
     pendingRefunds: pendingRefundCount.value,
   }
 })
 
-const normalUserCount = computed(
-  () => Math.max(0, adminStats.value.totalUsers - adminStats.value.totalCompanies - adminStats.value.totalAdmins),
-)
+const normalUserCount = computed(() => adminStats.value.totalUsers)
 
 const weeklySeries = computed(() => overview.value?.weeklyRecharge ?? [])
 const maxWeeklyAmount = computed(() => {

--- a/housekeeping-web/src/views/CompanyDashboardView.vue
+++ b/housekeeping-web/src/views/CompanyDashboardView.vue
@@ -3032,12 +3032,16 @@ onUnmounted(() => {
 
 .service-slots-cell {
   white-space: nowrap;
+  max-width: 220px;
+  overflow: hidden;
 }
 
 .service-slots {
-  display: inline-flex;
-  gap: 8px;
-  align-items: center;
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
 }
 
 .service-cell {

--- a/housekeeping-web/src/views/CompanyDashboardView.vue
+++ b/housekeeping-web/src/views/CompanyDashboardView.vue
@@ -452,7 +452,9 @@
                   <td>{{ item.name }}</td>
                   <td>{{ item.contact }}</td>
                   <td>{{ item.categoryName || '—' }}</td>
-                  <td>{{ formatServiceSlots(item.serviceTimeSlots) }}</td>
+                  <td class="service-slots-cell">
+                    <span class="service-slots">{{ formatServiceSlots(item.serviceTimeSlots) }}</span>
+                  </td>
                   <td>
                     <span class="status-badge" :class="item.assigned ? 'status-assigned' : 'status-available'">
                       {{ item.assigned ? '已分配' : '未分配' }}
@@ -3026,6 +3028,16 @@ onUnmounted(() => {
   vertical-align: top;
   color: var(--brand-text);
   text-align: left;
+}
+
+.service-slots-cell {
+  white-space: nowrap;
+}
+
+.service-slots {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
 }
 
 .service-cell {

--- a/housekeeping-web/src/views/CompanyDashboardView.vue
+++ b/housekeeping-web/src/views/CompanyDashboardView.vue
@@ -570,11 +570,11 @@
                     <div v-if="order.assignedWorker" class="order-subtext">
                       指派人员：{{ order.assignedWorker }}<span v-if="order.workerContact">（{{ order.workerContact }}）</span>
                     </div>
-                    <div v-if="order.specialRequest" class="order-subtext highlight">
-                      用户需求：{{ order.specialRequest }}
-                    </div>
-                  </td>
-                  <td>{{ formatOrderServiceWindow(order) }}</td>
+                <div v-if="order.specialRequest" class="order-subtext highlight">
+                  用户需求：{{ order.specialRequest }}
+                </div>
+              </td>
+              <td>{{ formatOrderServiceWindow(order) }}</td>
                   <td>{{ order.categoryName || '—' }}</td>
                   <td>{{ formatDateTime(order.createdAt) }}</td>
                   <td>{{ order.username }}</td>
@@ -592,29 +592,34 @@
                       {{ formatProgressText(order) }}
                     </div>
                   </td>
-                  <td>
-                    <button type="button" class="secondary-button" @click="openAssignmentModal(order)">
-                      指派人员
-                    </button>
-                  </td>
-                  <td class="table-actions actions-inline">
-                    <button
-                      type="button"
-                      class="link-button"
-                      :disabled="progressSaving[order.id] || appointmentsLoading"
-                      @click="saveOrderProgress(order, 'SCHEDULED')"
-                    >
-                      重置
-                    </button>
-                    <button
-                      type="button"
-                      class="link-button"
-                      :disabled="progressSaving[order.id] || appointmentsLoading"
-                      @click="saveOrderProgress(order, 'COMPLETED')"
-                    >
-                      完成
-                    </button>
-                    <button
+              <td>
+                <button
+                  type="button"
+                  class="secondary-button"
+                  :disabled="appointmentsLoading || !canEditCompanyOrder(order)"
+                  @click="openAssignmentModal(order)"
+                >
+                  指派人员
+                </button>
+              </td>
+              <td class="table-actions actions-inline">
+                <button
+                  type="button"
+                  class="link-button"
+                  :disabled="progressSaving[order.id] || appointmentsLoading || !canEditCompanyOrder(order)"
+                  @click="saveOrderProgress(order, 'SCHEDULED')"
+                >
+                  重置
+                </button>
+                <button
+                  type="button"
+                  class="link-button"
+                  :disabled="progressSaving[order.id] || appointmentsLoading || !canEditCompanyOrder(order)"
+                  @click="saveOrderProgress(order, 'COMPLETED')"
+                >
+                  完成
+                </button>
+                <button
                       type="button"
                       class="link-button danger"
                       :disabled="appointmentsLoading || !canDeleteCompanyOrder(order)"
@@ -1300,6 +1305,7 @@ const matchesOrderSearch = (order: ServiceOrderItem, keyword: string) => {
 }
 
 const canDeleteCompanyOrder = (order: ServiceOrderItem) => order.status === 'COMPLETED'
+const canEditCompanyOrder = (order: ServiceOrderItem) => order.status !== 'COMPLETED'
 
 const matchesReviewSearch = (review: ServiceReviewItem, keyword: string) => {
   if (!keyword) {
@@ -3262,4 +3268,3 @@ onUnmounted(() => {
   }
 }
 </style>
-

--- a/housekeeping-web/src/views/TouristLandingView.vue
+++ b/housekeeping-web/src/views/TouristLandingView.vue
@@ -122,31 +122,36 @@
         <p v-if="servicesError" class="error-tip">{{ servicesError }}</p>
         <div v-else class="service-grid">
           <article v-for="service in filteredServices" :key="service.id" class="service-card">
-            <h3 class="service-title">{{ service.name }}</h3>
-            <p class="service-company">提供方：{{ service.companyName }}</p>
-            <dl class="service-meta">
-              <div>
-                <dt>计价单位</dt>
-                <dd>{{ service.unit }}</dd>
-              </div>
-              <div>
-                <dt>服务价格</dt>
-                <dd>¥{{ service.price.toFixed(2) }}</dd>
-              </div>
-              <div>
-                <dt>联系方式</dt>
-                <dd>{{ service.contact }}</dd>
-              </div>
-              <div>
-                <dt>服务时长</dt>
-                <dd>{{ service.serviceTime }}</dd>
-              </div>
-            </dl>
-            <p v-if="service.description" class="service-desc">{{ service.description }}</p>
-            <footer class="service-card-footer">
-              <span v-if="service.categoryName" class="service-category-chip">{{ service.categoryName }}</span>
-              <p class="service-note">请登录后预约服务。</p>
-            </footer>
+            <div v-if="service.imageBase64" class="service-thumb">
+              <img :src="service.imageBase64" :alt="`${service.name} 封面图`" loading="lazy" />
+            </div>
+            <div class="service-card-body">
+              <h3 class="service-title">{{ service.name }}</h3>
+              <p class="service-company">提供方：{{ service.companyName }}</p>
+              <dl class="service-meta">
+                <div>
+                  <dt>计价单位</dt>
+                  <dd>{{ service.unit }}</dd>
+                </div>
+                <div>
+                  <dt>服务价格</dt>
+                  <dd>¥{{ service.price.toFixed(2) }}</dd>
+                </div>
+                <div>
+                  <dt>联系方式</dt>
+                  <dd>{{ service.contact }}</dd>
+                </div>
+                <div>
+                  <dt>服务时长</dt>
+                  <dd>{{ service.serviceTime }}</dd>
+                </div>
+              </dl>
+              <p v-if="service.description" class="service-desc">{{ service.description }}</p>
+              <footer class="service-card-footer">
+                <span v-if="service.categoryName" class="service-category-chip">{{ service.categoryName }}</span>
+                <p class="service-note">请登录后预约服务。</p>
+              </footer>
+            </div>
           </article>
           <p v-if="!filteredServices.length && !servicesLoading" class="empty-tip">
             {{ serviceSearch ? '未找到匹配的服务，请尝试调整搜索词。' : '暂无家政服务，稍后再来看看。' }}
@@ -737,14 +742,35 @@ onMounted(async () => {
 }
 
 .service-card {
-  padding: 20px;
+  padding: 0;
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.2);
   background: #f8fafc;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.08);
+}
+
+.service-thumb {
+  position: relative;
+  overflow: hidden;
+  border-radius: 16px 16px 0 0;
+  min-height: 160px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(14, 165, 233, 0.08));
+}
+
+.service-thumb img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.service-card-body {
+  padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.08);
 }
 
 .service-title {

--- a/housekeeping-web/src/views/UserDashboardView.vue
+++ b/housekeeping-web/src/views/UserDashboardView.vue
@@ -2670,12 +2670,18 @@ onUnmounted(() => {
 
 .discover-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+  gap: 1.25rem;
+}
+
+@media (min-width: 1080px) {
+  .discover-grid {
+    grid-template-columns: repeat(3, minmax(280px, 1fr));
+  }
 }
 
 .carousel {
-  grid-column: span 2;
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/housekeeping-web/src/views/UserDashboardView.vue
+++ b/housekeeping-web/src/views/UserDashboardView.vue
@@ -2671,13 +2671,23 @@ onUnmounted(() => {
 .discover-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  align-items: start;
+  align-items: stretch;
   gap: 1.25rem;
 }
 
 @media (min-width: 1080px) {
   .discover-grid {
-    grid-template-columns: repeat(3, minmax(280px, 1fr));
+    grid-template-columns: 2fr 1fr 1fr;
+    grid-auto-flow: column;
+  }
+  .carousel {
+    grid-column: 1 / 2;
+  }
+  .tips {
+    grid-column: 2 / 3;
+  }
+  .announcements {
+    grid-column: 3 / 4;
   }
 }
 

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/AccountTransactionRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/AccountTransactionRepository.java
@@ -17,4 +17,6 @@ public interface AccountTransactionRepository extends JpaRepository<AccountTrans
     List<AccountTransaction> findTop50ByOrderByCreatedAtDesc();
 
     List<AccountTransaction> findByTypeAndCreatedAtBetween(AccountTransactionType type, Instant start, Instant end);
+
+    void deleteByUser(UserAll user);
 }

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/CompanyMessageRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/CompanyMessageRepository.java
@@ -24,4 +24,8 @@ public interface CompanyMessageRepository extends JpaRepository<CompanyMessage, 
     List<CompanyMessage> findByOrderAndRecipientAndReadAtIsNull(ServiceOrder order, UserAll recipient);
 
     void deleteByOrder(ServiceOrder order);
+
+    void deleteByOrderIn(List<ServiceOrder> orders);
+
+    void deleteBySenderOrRecipient(UserAll sender, UserAll recipient);
 }

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceFavoriteRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceFavoriteRepository.java
@@ -17,4 +17,6 @@ public interface ServiceFavoriteRepository extends JpaRepository<ServiceFavorite
     long countByService(HousekeepService service);
 
     Optional<ServiceFavorite> findByUserAndService(UserAll user, HousekeepService service);
+
+    void deleteByUser(UserAll user);
 }

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceOrderRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceOrderRepository.java
@@ -19,5 +19,7 @@ public interface ServiceOrderRepository extends JpaRepository<ServiceOrder, Long
 
     List<ServiceOrder> findByServiceIn(List<HousekeepService> services);
 
+    List<ServiceOrder> findByHandledBy(UserAll handler);
+
     List<ServiceOrder> findByAssignedStaffIn(@Param("staff") List<com.example.housekeeping.entity.CompanyStaff> staff);
 }

--- a/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceReviewRepository.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/repository/ServiceReviewRepository.java
@@ -16,4 +16,6 @@ public interface ServiceReviewRepository extends JpaRepository<ServiceReview, Lo
     List<ServiceReview> findByServiceInOrderByCreatedAtDesc(List<HousekeepService> services);
 
     List<ServiceReview> findByUserOrderByCreatedAtDesc(UserAll user);
+
+    void deleteByUser(UserAll user);
 }

--- a/housekeeping/src/main/java/com/example/housekeeping/service/UserWalletService.java
+++ b/housekeeping/src/main/java/com/example/housekeeping/service/UserWalletService.java
@@ -17,9 +17,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
 
-/**
- * 用户钱包操作。
- */
 @Service
 public class UserWalletService {
 
@@ -93,5 +90,4 @@ public class UserWalletService {
         txn.setCreatedAt(Instant.now());
         accountTransactionRepository.save(txn);
     }
-
 }


### PR DESCRIPTION
## Summary
- show available service cover images in tourist mode cards with styling
- clean up messages, orders, favorites, reviews, and transactions before admin account deletions to avoid foreign-key failures
- clear handled-by references on orders when the handler account is removed

## Testing
- npm run build
- mvn -q -DskipTests compile (fails: remote repository access blocked: HTTP 403)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b3fafe260832da84d2300599d8be8)